### PR TITLE
Update links to Silver repository in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Carbon
 ======
 
 Carbon is a verification-condition-generation-based verifier for
-`the Viper intermediate verification language <https://bitbucket.org/viperproject/silver>`_.
+`the Viper intermediate verification language <https://github.com/viperproject/silver>`_.
 
 `The Viper project <http://www.pm.inf.ethz.ch/research/viper.html>`_ is developed by the
 `Programming Methodology <http://www.pm.inf.ethz.ch/>`_ group
@@ -16,7 +16,7 @@ See `the documentation wiki <https://bitbucket.org/viperproject/documentation/>`
 Installation Instructions:
 --------------------------
 
-* Clone `silver <https://bitbucket.org/viperproject/silver/>`_ repository in your computer.
+* Clone `silver <https://github.com/viperproject/silver/>`_ repository in your computer.
 * Clone **carbon** (this repository) in your computer, in a separate directory.
 * From within the directory where you installed carbon, create a symbolic link to the directory where you installed silver.
 * On Linux/Mac OS X::


### PR DESCRIPTION
The README currently references a couple repositories on BitBucket that don't exist; I'm guessing the whole Viper project moved from there recently.

This updates the README to point to the Silver repository on GitHub.

Note that the README still contains a broken link to a `documentation` repository on BitBucket, but that doesn't seem to have an equivalent on GitHub.