### PR TITLE
Use Java Process IO in BoogieInterface

### DIFF
--- a/src/main/scala/viper/carbon/Carbon.scala
+++ b/src/main/scala/viper/carbon/Carbon.scala
@@ -32,7 +32,7 @@ class CarbonFrontend(override val reporter: PluginAwareReporter,
   private var carbonInstance: CarbonVerifier = _
 
   def createVerifier(fullCmd: String) = {
-    carbonInstance = CarbonVerifier(Seq("Arguments: " -> fullCmd))
+    carbonInstance = CarbonVerifier(reporter.reporter, Seq("Arguments: " -> fullCmd))
 
     carbonInstance
   }

--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -13,7 +13,9 @@ import viper.silver.utility.Paths
 import viper.silver.verifier._
 import verifier.{BoogieDependency, BoogieInterface, Verifier}
 import java.io.{BufferedOutputStream, File, FileOutputStream, IOException}
+
 import viper.silver.frontend.MissingDependencyException
+import viper.silver.reporter.Reporter
 
 /**
  * The main class to perform verification of Viper programs.  Deals with command-line arguments, configuration
@@ -21,9 +23,8 @@ import viper.silver.frontend.MissingDependencyException
  *
  * Debug information can either be set using the constructor argument or the setter.
  */
-case class CarbonVerifier(private var _debugInfo: Seq[(String, Any)] = Nil) extends Verifier with viper.silver.verifier.Verifier with BoogieInterface {
-
-  def this() = this(Nil)
+case class CarbonVerifier(override val reporter: Reporter,
+                          private var _debugInfo: Seq[(String, Any)] = Nil) extends Verifier with viper.silver.verifier.Verifier with BoogieInterface {
 
   var env = null
 

--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -13,7 +13,6 @@ import viper.silver.utility.Paths
 import viper.silver.verifier._
 import verifier.{BoogieDependency, BoogieInterface, Verifier}
 import java.io.{BufferedOutputStream, File, FileOutputStream, IOException}
-
 import viper.silver.frontend.MissingDependencyException
 import viper.silver.reporter.Reporter
 

--- a/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
+++ b/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
@@ -2,20 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.carbon.verifier
 
-import viper.silver.verifier._
-
-import sys.process._
 import java.io._
 
-import viper.silver.verifier.Failure
+import viper.carbon.boogie.{Assert, Program}
+//import viper.silver.reporter.BackendSubProcessStages._
+//import viper.silver.reporter.{BackendSubProcessReport, Reporter}
 import viper.silver.verifier.errors.Internal
 import viper.silver.verifier.reasons.InternalReason
-import viper.carbon.boogie.Assert
-import viper.carbon.boogie.Program
+import viper.silver.verifier.{Failure, _}
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
+
 
 
 class BoogieDependency(_location: String) extends Dependency {
@@ -25,10 +27,12 @@ class BoogieDependency(_location: String) extends Dependency {
 }
 
 /**
- * Defines a clean interface to invoke Boogie and get a list of errors back.
- */
+  * Defines a clean interface to invoke Boogie and get a list of errors back.
+  */
 
 trait BoogieInterface {
+
+  //  def reporter: Reporter
 
   def defaultOptions = Seq("/vcsCores:" + java.lang.Runtime.getRuntime.availableProcessors,
     "/errorTrace:0",
@@ -53,7 +57,9 @@ trait BoogieInterface {
   /** The (resolved) path where Z3 is supposed to be located. */
   def z3Path: String
 
-  private var _boogieProcess:Process = null
+  private var _boogieProcess: Option[Process] = None
+  private var _boogieProcessPid: Option[Long] = None
+  private var _z3ProcessStream: Option[LazyList[ProcessHandle]] = None
 
   var errormap: Map[Int, VerificationError] = Map()
   var models : collection.mutable.ListBuffer[String] = new collection.mutable.ListBuffer[String]
@@ -86,8 +92,8 @@ trait BoogieInterface {
   }
 
   /**
-   * Parse the output of Boogie. Returns a pair of the detected version number and a sequence of error identifiers.
-   */
+    * Parse the output of Boogie. Returns a pair of the detected version number and a sequence of error identifiers.
+    */
   private def parse(output: String): (String,Seq[Int]) = {
     val LogoPattern = "Boogie program verifier version ([0-9.]+),.*".r
     val SummaryPattern = "Boogie program verifier finished with ([0-9]+) verified, ([0-9]+) error.*".r
@@ -128,8 +134,8 @@ trait BoogieInterface {
   }
 
   /**
-   * Invoke Boogie.
-   */
+    * Invoke Boogie.
+    */
   private def run(input: String, options: Seq[String]): String = {
     def convertStreamToString(is: java.io.InputStream) = {
       val s = new java.util.Scanner(is).useDelimiter("\\A")
@@ -137,62 +143,84 @@ trait BoogieInterface {
     }
     var res: String = ""
     var reserr: String = ""
-    def out(input: java.io.InputStream): Unit = {
+    def out(input: InputStream): Unit = {
+      //      reporter report BackendSubProcessReport("carbon", boogiePath, onOutput, _boogieProcessPid)
       res += convertStreamToString(input)
       input.close()
     }
-    def err(in: java.io.InputStream): Unit = {
+    def err(in: InputStream): Unit = {
+      //      reporter report BackendSubProcessReport("carbon", boogiePath, OnError, _boogieProcessPid)
       reserr += convertStreamToString(in)
       in.close()
     }
     // write program to a temporary file
     val tmp = File.createTempFile("carbon", ".bpl")
+
     tmp.deleteOnExit()
     val stream = new BufferedOutputStream(new FileOutputStream(tmp))
     stream.write(input.getBytes)
     stream.close()
 
-    // Note: call exitValue to block until Boogie has finished
-    // Note: we call boogie with an empty input "file" on stdin and parse the output
-    _boogieProcess = (Seq(boogiePath) ++ options ++ Seq(tmp.getAbsolutePath)).run(new ProcessIO(_.close(), out, err))
-    _boogieProcess.exitValue()
+    //    reporter report BackendSubProcessReport("carbon", boogiePath, BeforeInputSent, _boogieProcessPid)
+
+    val cmd: Seq[String] = (Seq(boogiePath) ++ options ++ Seq(tmp.getAbsolutePath))
+    val pb: ProcessBuilder = new ProcessBuilder(cmd.asJava)
+    val proc: Process = pb.start()
+    _boogieProcess = Some(proc)
+    _boogieProcessPid = Some(proc.pid)
+
+    proc.getOutputStream.close()
+
+    _z3ProcessStream = Some(proc.descendants().toScala(LazyList))
+    //    reporter report BackendSubProcessReport("carbon", boogiePath, AfterInputSent, _boogieProcessPid)
+    err(proc.getErrorStream)
+    out(proc.getInputStream)
+    proc.waitFor()
+
+    //    reporter report BackendSubProcessReport("carbon", boogiePath, OnExit, _boogieProcessPid)
     reserr + res
   }
 
   def stopBoogie(): Unit = {
-    if(_boogieProcess!= null){
-      _boogieProcess.destroy()
-     // _boogieProcess.exitValue()  // Issue 225: I understood by the documentation of this API that by destroying the
-    }                               // processes, the pipe connecting input and output is also deleted. Therefore
-                                    // there's no need to sync with a dying processes. Instead we are free to start a
-                                    // a new instance of Boogie/Z3. This was tested on a Mac successfully. However more
-                                    // testing is necessary and should it failed to work properly on all platforms, this
-                                    // line should be uncommented and the issue reopened.
+    _boogieProcess match {
+      case Some(proc) =>
+        //        reporter report BackendSubProcessReport("carbon", boogiePath, BeforeTermination, _boogieProcessPid)
+        proc.destroy()
+        _z3ProcessStream match {
+          case Some(stream) =>
+            stream.foreach((ph: ProcessHandle) => {
+              ph.destroy()
+            })
+          case None =>
+        }
+      //        reporter report BackendSubProcessReport("carbon", boogiePath, AfterTermination, _boogieProcessPid)
+      case None =>
+    }
   }
 
-/*  // TODO: investigate why passing the program directly does not work
-  private def runX(input: String, options: Seq[String]): String = {
-    def convertStreamToString(is: java.io.InputStream) = {
-      val s = new java.util.Scanner(is).useDelimiter("\\A")
-      if (s.hasNext) s.next() else ""
-    }
-    var res: String = ""
-    var reserr: String = ""
-    def out(input: java.io.InputStream) {
-      res += convertStreamToString(input)
-      input.close()
-    }
-    def err(in: java.io.InputStream) {
-      reserr += convertStreamToString(in)
-      in.close()
-    }
-    def in(output: java.io.OutputStream) {
-      output.write(input.getBytes)
-      output.close()
-    }
-    // Note: call exitValue to block until Boogie has finished
-    // Note: we call boogie with an empty input "file" on stdin and parse the output
-    (Seq(boogiePath) ++ options ++ Seq("stdin.bpl")).run(new ProcessIO(in, out, err)).exitValue()
-    reserr + res
-  }*/
+  /*  // TODO: investigate why passing the program directly does not work
+    private def runX(input: String, options: Seq[String]): String = {
+      def convertStreamToString(is: java.io.InputStream) = {
+        val s = new java.util.Scanner(is).useDelimiter("\\A")
+        if (s.hasNext) s.next() else ""
+      }
+      var res: String = ""
+      var reserr: String = ""
+      def out(input: java.io.InputStream) {
+        res += convertStreamToString(input)
+        input.close()
+      }
+      def err(in: java.io.InputStream) {
+        reserr += convertStreamToString(in)
+        in.close()
+      }
+      def in(output: java.io.OutputStream) {
+        output.write(input.getBytes)
+        output.close()
+      }
+      // Note: call exitValue to block until Boogie has finished
+      // Note: we call boogie with an empty input "file" on stdin and parse the output
+      (Seq(boogiePath) ++ options ++ Seq("stdin.bpl")).run(new ProcessIO(in, out, err)).exitValue()
+      reserr + res
+    }*/
 }

--- a/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
+++ b/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
@@ -59,7 +59,10 @@ trait BoogieInterface {
 
   private var _boogieProcess: Option[Process] = None
   private var _boogieProcessPid: Option[Long] = None
-  private var _z3ProcessStream: Option[LazyList[ProcessHandle]] = None
+
+  // Z3 processes cannot be collected this way, perhaps because they are not created using Java 9 API (but via Boogie).
+  // Hence, for now we have to trust Boogie to manage its own sub-processes.
+  // private var _z3ProcessStream: Option[LazyList[ProcessHandle]] = None
 
   var errormap: Map[Int, VerificationError] = Map()
   var models : collection.mutable.ListBuffer[String] = new collection.mutable.ListBuffer[String]
@@ -144,7 +147,7 @@ trait BoogieInterface {
     var res: String = ""
     var reserr: String = ""
     def out(input: InputStream): Unit = {
-      reporter report BackendSubProcessReport("carbon", boogiePath, onOutput, _boogieProcessPid)
+      reporter report BackendSubProcessReport("carbon", boogiePath, OnOutput, _boogieProcessPid)
       res += convertStreamToString(input)
       input.close()
     }
@@ -171,7 +174,7 @@ trait BoogieInterface {
 
     proc.getOutputStream.close()
 
-    _z3ProcessStream = Some(proc.descendants().toScala(LazyList))
+    // _z3ProcessStream = Some(proc.descendants().toScala(LazyList))
     reporter report BackendSubProcessReport("carbon", boogiePath, AfterInputSent, _boogieProcessPid)
     err(proc.getErrorStream)
     out(proc.getInputStream)
@@ -186,14 +189,14 @@ trait BoogieInterface {
       case Some(proc) =>
         reporter report BackendSubProcessReport("carbon", boogiePath, BeforeTermination, _boogieProcessPid)
         proc.destroy()
-        _z3ProcessStream match {
+        /*_z3ProcessStream match {
           case Some(stream) =>
             stream.foreach((ph: ProcessHandle) => {
               ph.destroy()
             })
           case None =>
-        }
-      reporter report BackendSubProcessReport("carbon", boogiePath, AfterTermination, _boogieProcessPid)
+        }*/
+        reporter report BackendSubProcessReport("carbon", boogiePath, AfterTermination, _boogieProcessPid)
       case None =>
     }
   }

--- a/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
+++ b/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
@@ -9,8 +9,8 @@ package viper.carbon.verifier
 import java.io._
 
 import viper.carbon.boogie.{Assert, Program}
-//import viper.silver.reporter.BackendSubProcessStages._
-//import viper.silver.reporter.{BackendSubProcessReport, Reporter}
+import viper.silver.reporter.BackendSubProcessStages._
+import viper.silver.reporter.{BackendSubProcessReport, Reporter}
 import viper.silver.verifier.errors.Internal
 import viper.silver.verifier.reasons.InternalReason
 import viper.silver.verifier.{Failure, _}
@@ -32,7 +32,7 @@ class BoogieDependency(_location: String) extends Dependency {
 
 trait BoogieInterface {
 
-  //  def reporter: Reporter
+  def reporter: Reporter
 
   def defaultOptions = Seq("/vcsCores:" + java.lang.Runtime.getRuntime.availableProcessors,
     "/errorTrace:0",
@@ -144,12 +144,12 @@ trait BoogieInterface {
     var res: String = ""
     var reserr: String = ""
     def out(input: InputStream): Unit = {
-      //      reporter report BackendSubProcessReport("carbon", boogiePath, onOutput, _boogieProcessPid)
+      reporter report BackendSubProcessReport("carbon", boogiePath, onOutput, _boogieProcessPid)
       res += convertStreamToString(input)
       input.close()
     }
     def err(in: InputStream): Unit = {
-      //      reporter report BackendSubProcessReport("carbon", boogiePath, OnError, _boogieProcessPid)
+      reporter report BackendSubProcessReport("carbon", boogiePath, OnError, _boogieProcessPid)
       reserr += convertStreamToString(in)
       in.close()
     }
@@ -161,7 +161,7 @@ trait BoogieInterface {
     stream.write(input.getBytes)
     stream.close()
 
-    //    reporter report BackendSubProcessReport("carbon", boogiePath, BeforeInputSent, _boogieProcessPid)
+    reporter report BackendSubProcessReport("carbon", boogiePath, BeforeInputSent, _boogieProcessPid)
 
     val cmd: Seq[String] = (Seq(boogiePath) ++ options ++ Seq(tmp.getAbsolutePath))
     val pb: ProcessBuilder = new ProcessBuilder(cmd.asJava)
@@ -172,19 +172,19 @@ trait BoogieInterface {
     proc.getOutputStream.close()
 
     _z3ProcessStream = Some(proc.descendants().toScala(LazyList))
-    //    reporter report BackendSubProcessReport("carbon", boogiePath, AfterInputSent, _boogieProcessPid)
+    reporter report BackendSubProcessReport("carbon", boogiePath, AfterInputSent, _boogieProcessPid)
     err(proc.getErrorStream)
     out(proc.getInputStream)
     proc.waitFor()
 
-    //    reporter report BackendSubProcessReport("carbon", boogiePath, OnExit, _boogieProcessPid)
+    reporter report BackendSubProcessReport("carbon", boogiePath, OnExit, _boogieProcessPid)
     reserr + res
   }
 
   def stopBoogie(): Unit = {
     _boogieProcess match {
       case Some(proc) =>
-        //        reporter report BackendSubProcessReport("carbon", boogiePath, BeforeTermination, _boogieProcessPid)
+        reporter report BackendSubProcessReport("carbon", boogiePath, BeforeTermination, _boogieProcessPid)
         proc.destroy()
         _z3ProcessStream match {
           case Some(stream) =>
@@ -193,7 +193,7 @@ trait BoogieInterface {
             })
           case None =>
         }
-      //        reporter report BackendSubProcessReport("carbon", boogiePath, AfterTermination, _boogieProcessPid)
+      reporter report BackendSubProcessReport("carbon", boogiePath, AfterTermination, _boogieProcessPid)
       case None =>
     }
   }

--- a/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
+++ b/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
@@ -158,7 +158,6 @@ trait BoogieInterface {
     }
     // write program to a temporary file
     val tmp = File.createTempFile("carbon", ".bpl")
-
     tmp.deleteOnExit()
     val stream = new BufferedOutputStream(new FileOutputStream(tmp))
     stream.write(input.getBytes)

--- a/src/test/scala/viper/carbon/AllTests.scala
+++ b/src/test/scala/viper/carbon/AllTests.scala
@@ -12,7 +12,7 @@ import viper.silver.frontend.Frontend
 import java.nio.file.Path
 
 import viper.silver.logger.SilentLogger
-import viper.silver.reporter.NoopReporter
+import viper.silver.reporter.{NoopReporter, StdIOReporter}
 
 /** All tests for carbon.
 
@@ -31,5 +31,5 @@ class AllTests extends SilSuite {
     fe
   }
 
-  lazy val verifiers = List(CarbonVerifier())
+  lazy val verifiers = List(CarbonVerifier(StdIOReporter()))
 }

--- a/src/test/scala/viper/carbon/CarbonBackendTypeTest.scala
+++ b/src/test/scala/viper/carbon/CarbonBackendTypeTest.scala
@@ -1,8 +1,9 @@
 package viper.carbon
 
+import viper.silver.reporter.StdIOReporter
 import viper.silver.testing.BackendTypeTest
 import viper.silver.verifier.Verifier
 
 class CarbonBackendTypeTest extends BackendTypeTest {
-  override val verifier: Verifier = CarbonVerifier()
+  override val verifier: Verifier = CarbonVerifier(StdIOReporter())
 }

--- a/src/test/scala/viper/carbon/GraphTests.scala
+++ b/src/test/scala/viper/carbon/GraphTests.scala
@@ -2,17 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.carbon
 
 import java.nio.file.Path
 
 import org.scalatest.DoNotDiscover
-
 import viper.silver.frontend.Frontend
 import viper.silver.logger.SilentLogger
-import viper.silver.reporter.NoopReporter
+import viper.silver.reporter.{NoopReporter, StdIOReporter}
 import viper.silver.testing.SilSuite
 import viper.silver.verifier.Verifier
 
@@ -32,5 +31,5 @@ class GraphTests extends SilSuite {
     fe
   }
 
-  lazy val verifiers = List(CarbonVerifier())
+  lazy val verifiers = List(CarbonVerifier(StdIOReporter()))
 }

--- a/src/test/scala/viper/carbon/PortableCarbonTests.scala
+++ b/src/test/scala/viper/carbon/PortableCarbonTests.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2019 ETH Zurich.
+// Copyright (c) 2011-2021 ETH Zurich.
 
 package viper.carbon
 
@@ -76,11 +76,12 @@ class PortableCarbonTests extends SilSuite with StatisticalTestSuite {
   override val targetLocationPropertyName = "CARBONTESTS_TARGET"
   override val csvFilePropertyName = "CARBONTESTS_CSV"
 
-  override def verifier: CarbonVerifier = CarbonVerifier()
+  val reporter = NoopReporter
+  override def verifier: CarbonVerifier = CarbonVerifier(reporter)
 
   override def frontend(verifier: Verifier, files: Seq[Path]): Frontend = {
     require(files.length == 1, "tests should consist of exactly one file")
-    val fe = new CarbonFrontend(NoopReporter, SilentLogger().get)
+    val fe = new CarbonFrontend(reporter, SilentLogger().get)
     fe.init(verifier)
     fe.reset(files.head)
     fe


### PR DESCRIPTION
This PR improves process management in ```BoogieInterface``` by ensuring that all potential Z3 sub-processes of Boogie are destroyed. 

Scala Process API that has been used before is too abstract and does not provide some essentials. For example, using that API, one cannot get a PID of a process that one creates. Working with process trees is also not possible. Conversely, the Java Process API (which I suggest using) was released a few years ago (so it should be stable) is more powerful and does cover the above scenarios. 

Note: the commented out lines should allow for the test to pass before https://github.com/viperproject/silver is merged. 