### PR TITLE
Removed a bad trigger in known folded permissions axiom

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -168,7 +168,9 @@ class DefaultHeapModule(val verifier: Verifier)
         MaybeCommentedDecl("Frame all locations with known folded permissions", Axiom(Forall(
           vars ++ Seq(predField),
           //Trigger(Seq(identicalFuncApp, lookup(h.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
-          Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predField.l), isPredicateField(predField.l))) /*++
+          // Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predField.l), isPredicateField(predField.l)))
+          Trigger(Seq(identicalFuncApp, isPredicateField(predField.l)))
+          /*++
             Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
             (verifier.program.predicates map (pred =>
               Trigger(Seq(identicalFuncApp, predicateTriggerAnyState(pred, predField.l), isPredicateField(predField.l))))


### PR DESCRIPTION
In its current version, Carbon does not verify the following program, even though it should be able to thanks to known folded permissions: 

```
field val: Int

predicate knownFolded(x: Ref) {
    acc(x.val, 1/2)
}

method test(x: Ref, y: Ref)
    requires acc(x.val, 1/2) && x.val == 5
    requires acc(y.val)
{
    fold knownFolded(x)
    exhale acc(y.val)
    inhale acc(x.val, 1/2)
    assert x.val == 5
}
```

The reason is that the known folded permissions axiom for predicates uses the trigger 

> ExhaleHeap[null, pm_f]

which has to do with the interaction between functions and predicates. This PR simply removes this trigger, as shown below, and thus makes the program above verify.

Axiom in the current version of Carbon:
```
axiom (forall <C> Heap: HeapType, ExhaleHeap: HeapType, Mask: MaskType, pm_f: (Field C FrameType) ::
  { IdenticalOnKnownLocations(Heap, ExhaleHeap, Mask), ExhaleHeap[null, pm_f], IsPredicateField(pm_f) }
  IdenticalOnKnownLocations(Heap, ExhaleHeap, Mask) ==> HasDirectPerm(Mask, null, pm_f) && IsPredicateField(pm_f) ==> (forall <A, B> o2: Ref, f_2: (Field A B) ::
    { ExhaleHeap[o2, f_2] }
    Heap[null, PredicateMaskField(pm_f)][o2, f_2] ==> Heap[o2, f_2] == ExhaleHeap[o2, f_2]
  )
);
```

Axiom in this PR:
```
axiom (forall <C> Heap: HeapType, ExhaleHeap: HeapType, Mask: MaskType, pm_f: (Field C FrameType) ::
  { IdenticalOnKnownLocations(Heap, ExhaleHeap, Mask), IsPredicateField(pm_f) }
  IdenticalOnKnownLocations(Heap, ExhaleHeap, Mask) ==> HasDirectPerm(Mask, null, pm_f) && IsPredicateField(pm_f) ==> (forall <A, B> o2: Ref, f_2: (Field A B) ::
    { ExhaleHeap[o2, f_2] }
    Heap[null, PredicateMaskField(pm_f)][o2, f_2] ==> Heap[o2, f_2] == ExhaleHeap[o2, f_2]
  )
);
```