### PR TITLE
Dynamic labelled old

### DIFF
--- a/src/main/scala/viper/carbon/modules/StateModule.scala
+++ b/src/main/scala/viper/carbon/modules/StateModule.scala
@@ -89,6 +89,17 @@ trait StateModule extends Module with ComponentRegistry[CarbonStateComponent] wi
   def freshTempState(name: String, discardCurrent: Boolean = false, initialise: Boolean = false): (Stmt, StateSnapshot)
 
   /**
+    * Returns a fresh state that is not an old state. This method has no side-effects on the current state.
+    */
+  def freshTempStateKeepCurrent(name: String) : StateSnapshot
+
+  /**
+    * Returns the statement that initializes the input state to the current state. This method has no side-effects on
+    * the current state.
+    */
+  def initToCurrentStmt(snapshot: StateSnapshot) : Stmt
+
+  /**
    * Create a state without any information and return a snapshot of the created state.
    * if init is true then the Stmt returned will contain the initialization according to the state
    * components

--- a/src/main/scala/viper/carbon/modules/StmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/StmtModule.scala
@@ -25,7 +25,7 @@ import viper.carbon.boogie.{Exp, Stmt, TrueLit}
 trait StmtModule extends Module with ComponentRegistry[StmtComponent] {
 
   /**
-    * Return initial statement to be used at beginning method body encoding (for example, code for labels).
+    * Return initial statement to be used at the beginning of the method body encoding (for example, code for labels).
     * This method also sets up the internal state of the module and should thus be invoked before any statements are
     * translated
     */

--- a/src/main/scala/viper/carbon/modules/StmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/StmtModule.scala
@@ -23,5 +23,15 @@ import viper.carbon.boogie.{Exp, Stmt, TrueLit}
   * For more details refer to the general note in 'wandModule'.
   */
 trait StmtModule extends Module with ComponentRegistry[StmtComponent] {
+
+  /**
+    * Return initial statement to be used at beginning method body encoding (for example, code for labels).
+    * This method also sets up the internal state of the module and should thus be invoked before any statements are
+    * translated
+    */
+  def initStmt(methodBody: sil.Stmt) : Stmt
+
   def translateStmt(stmt: sil.Stmt, statesStackForPackageStmt: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): Stmt
+
+
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -90,7 +90,14 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
         if(findLabel.equals("lhs"))
           findLabel = findLabel+wandModule.getActiveLhs()
         val prevState = stateModule.state
-        stateModule.replaceState(stateModule.stateRepositoryGet(findLabel).get)
+        val labelState = stateModule.stateRepositoryGet(findLabel).fold(
+          {
+            val s = stateModule.freshTempStateKeepCurrent("Label"+findLabel)
+            stateModule.stateRepositoryPut(findLabel, s)
+            s
+          })(identity)
+
+        stateModule.replaceState(labelState)
         val res = translateExp(exp)
         stateModule.replaceState(prevState)
         res

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -57,15 +57,6 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
     }
   }
 
-  def getLabelState(labelName: String): StateSnapshot = {
-    stateModule.stateRepositoryGet(labelName).fold(
-      {
-        val s = stateModule.freshTempStateKeepCurrent("Label"+labelName)
-        stateModule.stateRepositoryPut(labelName, s)
-        s
-      })(identity)
-  }
-
   override def translateExp(e: sil.Exp): Exp = {
     e match {
       case sil.IntLit(i) =>

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -118,7 +118,7 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
             val initOldStateComment = "Initializing of old state"
             val ins: Seq[LocalVarDecl] = formalArgs map translateLocalVarDecl
             val outs: Seq[LocalVarDecl] = formalReturns map translateLocalVarDecl
-            val init = MaybeCommentBlock("Initializing the state", stateModule.initBoogieState ++ assumeAllFunctionDefinitions)
+            val init = MaybeCommentBlock("Initializing the state", stateModule.initBoogieState ++ assumeAllFunctionDefinitions ++ stmtModule.initStmt(method.bodyOrAssumeFalse))
             val initOld = MaybeCommentBlock("Initializing the old state", stateModule.initOldState)
             val paramAssumptions = m.formalArgs map (a => allAssumptionsAboutValue(a.typ, translateLocalVarDecl(a), true))
             val inhalePre = translateMethodDeclPre(pres)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -13,6 +13,7 @@ import viper.carbon.boogie.Implicits._
 import viper.carbon.modules.components.CarbonStateComponent
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
  * The default implementation of a [[viper.carbon.modules.StateModule]].
@@ -132,6 +133,24 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
     }
     usingOldState = false // we have now set up a temporary state in terms of "old" - this could happen when an unfolding expression is inside an "old"
     (s, previousState)
+  }
+
+  override def freshTempStateKeepCurrent(name: String) : StateSnapshot = {
+    val freshState = new StateComponentMapping()
+
+    for (c <- components) yield {
+      val tmpExps = c.freshTempState(name)
+      freshState.put(c, tmpExps)
+    }
+
+    (freshState, false, false)
+  }
+
+  override def initToCurrentStmt(snapshot: StateSnapshot) : Stmt = {
+    for (e <- snapshot._1.entrySet().asScala.toSeq) yield {
+      val s: Stmt = (e.getValue zip e.getKey.currentStateExps) map (x => x._1 := x._2)
+      s
+    }
   }
 
   def freshEmptyState(name: String, init: Boolean = false): (Stmt, StateSnapshot) =

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -235,7 +235,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
         //first label, then init statement: otherwise gotos to this label will skip the initialization
         Label(Lbl(Identifier(name)(lblNamespace))) ++
           stateModule.initToCurrentStmt(labelState) ++
-          (labelBooleanGuards(name).l := TrueLit())  //label is defined
+          labelBooleanGuards.get(name).fold[Stmt](Nil)(labelGuardDecl => Seq(labelGuardDecl.l := TrueLit()))  //label is defined
       }
       case sil.Goto(target) =>
         Goto(Lbl(Identifier(target)(lblNamespace)))
@@ -315,7 +315,11 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
     if(makeChecks) {
       e match {
         case labelOld@sil.LabelledOld(_, labelName) =>
-          Assert(labelBooleanGuards(labelName).l, error.dueTo(reasons.LabelledStateNotReached(labelOld)))
+          labelBooleanGuards.get(labelName) match {
+            case Some(labelGuardDecl) =>
+              Assert(labelGuardDecl.l, error.dueTo(reasons.LabelledStateNotReached(labelOld)))
+            case None => Nil
+          }
         case _ => Nil
       }
     } else Nil

--- a/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
+++ b/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
@@ -1,0 +1,31 @@
+package viper.carbon.modules.impls
+
+import viper.carbon.modules.StateModule
+
+object LabelHelper {
+
+  /**
+    * Would prefer to use a method that takes a state module as input, but since it would have a dependent return
+    * (stateModule.StateSnapshot) IntelliJ can report false errors for callers.
+    * @param labelName
+    * @param freshTempStateNoSideEffect provide a fresh state without any side effects
+    * @param getSnapshot obtain a stored snapshot
+    * @param storeSnapshot store a snapshot
+    * @tparam T: state snapshot representation
+    * @return state snapshot associated with input label
+    */
+  def getLabelState[T](labelName: String,
+                       freshTempStateNoSideEffect: String => T,
+                       getSnapshot: String => Option[T],
+                       storeSnapshot: (String, T) => Unit): T = {
+    getSnapshot(labelName) match {
+      case Some(labelState) => labelState
+      case None => {
+        val s = freshTempStateNoSideEffect("Label"+labelName)
+        storeSnapshot(labelName,s)
+        s
+      }
+    }
+  }
+
+}

--- a/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
+++ b/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
@@ -5,7 +5,7 @@ import viper.carbon.modules.StateModule
 object LabelHelper {
 
   /**
-    * Would prefer to use a method that takes a state module as input, but since it would have a dependent return
+    * Would prefer to use a method that takes a state module as input, but since it would have a dependent return type
     * (stateModule.StateSnapshot) IntelliJ can report false errors for callers.
     * @param labelName
     * @param freshTempStateNoSideEffect provide a fresh state without any side effects


### PR DESCRIPTION
This pull request adds support for dynamic labels, which enables referring to labels that are only defined via certain traces as long as a referred label is defined in every trace that reaches it. As a side result, Carbon does not crash anymore when labels are accessed in a position that occurs later than when the labels are defined (syntactically).

For example: 
```if(b) { x.f := 42; label l} assert b ⇒ old[l](x.f == 42)``` verifies now, while it crashed before.