### PR TITLE
Add support for loops formed via gotos

### DIFF
--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -61,6 +61,7 @@ case class CarbonVerifier(private var _debugInfo: Seq[(String, Any)] = Nil) exte
   val setModule = new DefaultSetModule(this)
   val mapModule = new DefaultMapModule(this)
   val wandModule = new DefaultWandModule(this)
+  val loopModule = new DefaultLoopModule(this)
 
   // initialize all modules
   allModules foreach (m => {

--- a/src/main/scala/viper/carbon/modules/HeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/HeapModule.scala
@@ -18,6 +18,11 @@ import viper.silver.ast.{LocationAccess, MagicWand}
 trait HeapModule extends Module with CarbonStateComponent {
 
   /**
+    * The type used for heaps
+    */
+  def heapType: Type
+
+  /**
    * The type used for references.
    */
   def refType: Type
@@ -172,4 +177,8 @@ trait HeapModule extends Module with CarbonStateComponent {
 
   // adds permission to field e to the secondary mask of the wand
   def addPermissionToWMask(wMask: Exp, e: sil.Exp): Stmt
+
+  // If expression evaluates to true then resultHeap is the sum of of heap1, where mask1 is defined,
+  // and heap2, where mask2 is defined.
+  def sumHeap(resultHeap: Exp, heap1: Exp, mask1: Exp, heap2: Exp, mask2: Exp): Exp
 }

--- a/src/main/scala/viper/carbon/modules/LoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/LoopModule.scala
@@ -1,0 +1,18 @@
+package viper.carbon.modules
+
+import viper.silver.{ast => sil}
+
+trait LoopModule extends Module {
+
+  /* Returns method annotated with loop information and initializes loop module accordingly.
+   * This must be called before starting the method translation and the returned method should be used for the
+   * translation.
+   */
+  def initializeMethod(m: sil.Method): sil.Method
+
+  // Return true iff the statement is solely used for the loop module itself and is irrelevant otherwise.
+  def isLoopDummyStmt(s: sil.Stmt) : Boolean
+
+  // Return true iff the axioms to sum states is required.
+  def sumOfStatesAxiomRequired : Boolean
+}

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -84,6 +84,11 @@ trait PermModule extends Module with CarbonStateComponent {
   def wandMaskField(wand: Exp): Exp
 
   /**
+    * The type used for masks.
+    */
+  def maskType: Type
+
+  /**
    * The type used to for predicate masks.
    */
   def pmaskType: Type
@@ -114,7 +119,23 @@ trait PermModule extends Module with CarbonStateComponent {
   def sumMask(assmsToSmt: Exp => Stmt):Stmt
   */
 
+  /**
+    *
+    * @param summandMask1
+    * @param summandMask2
+    * @return expression for which its validity implies that the current mask is the sum of the two input masks
+    */
   def sumMask(summandMask1: Seq[Exp], summandMask2: Seq[Exp]): Exp
+
+  /**
+    *
+    * @param resultMask
+    * @param summandMask1
+    * @param summandMask2
+    * @return expression for which its validity implies that @{code resultMask} is the sum of the other two input
+    *         masks
+    */
+  def sumMask(resultMask: Seq[Exp], summandMask1: Seq[Exp], summandMask2: Seq[Exp]) : Exp
 
     /** returns a mask and the returned statement ensures that the mask  has non-zero permission at rcv.loc and zero
       * permission at all other location

--- a/src/main/scala/viper/carbon/modules/StmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/StmtModule.scala
@@ -8,7 +8,7 @@ package viper.carbon.modules
 
 import viper.carbon.modules.components.{ComponentRegistry, StmtComponent}
 import viper.silver.{ast => sil}
-import viper.carbon.boogie.{Exp, Stmt, TrueLit}
+import viper.carbon.boogie.{Exp, Namespace, Stmt, TrueLit}
 
 /**
  * A module for translating Viper statements.
@@ -24,4 +24,6 @@ import viper.carbon.boogie.{Exp, Stmt, TrueLit}
   */
 trait StmtModule extends Module with ComponentRegistry[StmtComponent] {
   def translateStmt(stmt: sil.Stmt, statesStackForPackageStmt: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): Stmt
+
+  def labelNamespace: Namespace
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -91,11 +91,13 @@ class DefaultHeapModule(val verifier: Verifier)
   private val succHeapName = Identifier("succHeap")
   private val succHeapTransName = Identifier("succHeapTrans")
   private val identicalOnKnownLocsName = Identifier("IdenticalOnKnownLocations")
+  private val identicalOnKnownLocsLiberalName = Identifier("IdenticalOnKnownLocationsLiberal")
   private val isPredicateFieldName = Identifier("IsPredicateField")
   private var PredIdMap:Map[String, BigInt] = Map()
   private var NextPredicateId:BigInt = 0
   private val isWandFieldName = Identifier("IsWandField")
   private val getPredicateIdName = Identifier("getPredicateId")
+  private val sumHeapName = Identifier("SumHeap")
 
   override def refType = NamedType("Ref")
 
@@ -107,6 +109,8 @@ class DefaultHeapModule(val verifier: Verifier)
     val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
     val predField = LocalVarDecl(Identifier("pm_f")(axiomNamespace),
       predicateVersionFieldType("C"))
+    val useSumOfStatesAxioms = loopModule.sumOfStatesAxiomRequired
+
     TypeDecl(refType) ++
       GlobalVarDecl(heapName, heapTyp) ++
       ConstDecl(nullName, refType) ++
@@ -131,6 +135,13 @@ class DefaultHeapModule(val verifier: Verifier)
       Func(identicalOnKnownLocsName,
         Seq(LocalVarDecl(heapName, heapTyp), LocalVarDecl(exhaleHeapName, heapTyp)) ++ staticMask,
         Bool) ++
+      {
+        if(useSumOfStatesAxioms)
+          Func(identicalOnKnownLocsLiberalName,
+            Seq(LocalVarDecl(heapName, heapTyp), LocalVarDecl(exhaleHeapName, heapTyp)) ++ staticMask,
+            Bool)
+        else Nil
+      } ++
       Func(isPredicateFieldName,
         Seq(LocalVarDecl(Identifier("f"), fieldType)),
         Bool) ++
@@ -139,7 +150,15 @@ class DefaultHeapModule(val verifier: Verifier)
         Bool) ++
       Func(getPredicateIdName,
         Seq(LocalVarDecl(Identifier("f"), fieldType)),
-        Int) ++ {
+        Int) ++
+      {
+        if(useSumOfStatesAxioms)
+          Func(sumHeapName,
+            Seq(LocalVarDecl(heapName, heapTyp), LocalVarDecl(heap1Name, heapTyp), LocalVarDecl(Identifier("mask1"), maskType),
+              LocalVarDecl(heap2Name, heapTyp), LocalVarDecl(Identifier("mask2"), maskType)),
+            Bool)
+        else Nil
+      } ++ {
       val h = LocalVarDecl(heapName, heapTyp)
       val eh = LocalVarDecl(exhaleHeapName, heapTyp)
       val h0 = LocalVarDecl(heap0Name, heapTyp)
@@ -147,78 +166,12 @@ class DefaultHeapModule(val verifier: Verifier)
       val h2 = LocalVarDecl(heap2Name, heapTyp)
       val vars = Seq(h, eh) ++ staticMask
       val identicalFuncApp = FuncApp(identicalOnKnownLocsName, vars map (_.l), Bool)
-      // frame all locations with direct permission
-      MaybeCommentedDecl("Frame all locations with direct permissions", Axiom(Forall(
-        vars ++ Seq(obj, field),
-//        Trigger(Seq(identicalFuncApp, lookup(h.l, obj.l, field.l))) ++
-          Trigger(Seq(identicalFuncApp, lookup(eh.l, obj.l, field.l))),
-        identicalFuncApp ==>
-          (staticPermissionPositive(obj.l, field.l) ==>
-            (lookup(h.l, obj.l, field.l) === lookup(eh.l, obj.l, field.l)))
-      )), size = 1) ++
-        // frame all predicate masks
-        MaybeCommentedDecl("Frame all predicate mask locations of predicates with direct permission", Axiom(Forall(
-          vars ++ Seq(predField),
-          Trigger(Seq(identicalFuncApp, isPredicateField(predField.l), lookup(eh.l, nullLit, predicateMaskField(predField.l)))),
-          identicalFuncApp ==>
-            ((staticPermissionPositive(nullLit, predField.l) && isPredicateField(predField.l)) ==>
-              (lookup(h.l, nullLit, predicateMaskField(predField.l)) === lookup(eh.l, nullLit, predicateMaskField(predField.l))))
-        )), size = 1) ++
-        // frame all locations with direct permission
-        MaybeCommentedDecl("Frame all locations with known folded permissions", Axiom(Forall(
-          vars ++ Seq(predField),
-          //Trigger(Seq(identicalFuncApp, lookup(h.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
-          Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predField.l), isPredicateField(predField.l))) /*++
-            Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
-            (verifier.program.predicates map (pred =>
-              Trigger(Seq(identicalFuncApp, predicateTriggerAnyState(pred, predField.l), isPredicateField(predField.l))))
-              )*/,
-          identicalFuncApp ==>
-            (
-              (staticPermissionPositive(nullLit, predField.l) && isPredicateField(predField.l)) ==>
-                Forall(Seq(obj2, field),
-                  //Trigger(Seq(lookup(h.l, obj2.l, field.l))) ++
-                    Trigger(Seq(lookup(eh.l, obj2.l, field.l))),
-                  (lookup(lookup(h.l, nullLit, predicateMaskField(predField.l)), obj2.l, field.l) ==>
-                    (lookup(h.l, obj2.l, field.l) === lookup(eh.l, obj2.l, field.l))),
-                  field.typ.freeTypeVars
-                )
-              )
-        )), size = 1)  ++
-      // frame all wand masks
-      MaybeCommentedDecl("Frame all wand mask locations of wands with direct permission", Axiom(Forall(
-        vars ++ Seq(predField),
-        Trigger(Seq(identicalFuncApp, isWandField(predField.l), lookup(eh.l, nullLit, wandMaskField(predField.l)))),
-        identicalFuncApp ==>
-          ((staticPermissionPositive(nullLit, predField.l) && isWandField(predField.l)) ==>
-            (lookup(h.l, nullLit, wandMaskField(predField.l)) === lookup(eh.l, nullLit, wandMaskField(predField.l))))
-      )), size = 1) ++
-        MaybeCommentedDecl("Frame all locations in the footprint of magic wands", Axiom(Forall(
-          vars ++ Seq(predField),
-          Trigger(Seq(identicalFuncApp, isWandField(predField.l)))
-              ,
-          identicalFuncApp ==>
-            (
-              (staticPermissionPositive(nullLit, predField.l) && isWandField(predField.l)) ==>
-                Forall(Seq(obj2, field),
-                  Trigger(Seq(lookup(eh.l, obj2.l, field.l))),
-                  (lookup(lookup(h.l, nullLit, wandMaskField(predField.l)), obj2.l, field.l) ==>
-                    (lookup(h.l, obj2.l, field.l) === lookup(eh.l, obj2.l, field.l))),
-                  field.typ.freeTypeVars
-                )
-              )
-        )), size = 1) ++
-      (if(enableAllocationEncoding) // preserve "allocated" knowledge, where already true
-        MaybeCommentedDecl("All previously-allocated references are still allocated", Axiom(Forall(
-          vars ++ Seq(obj),
-          /*Trigger(Seq(identicalFuncApp, lookup(h.l, obj.l, Const(allocName)))) ++*/
-            Trigger(Seq(identicalFuncApp, lookup(eh.l, obj.l, Const(allocName)))),
-          identicalFuncApp ==>
-              (lookup(h.l, obj.l, Const(allocName)) ==> lookup(eh.l, obj.l, Const(allocName)))
-        )), size = 1) else Nil) ++
+      val identicalLiberalFuncApp = FuncApp(identicalOnKnownLocsLiberalName, vars map (_.l), Bool)
+
+      identicalOnKnownLocsAxioms(false) ++
         MaybeCommentedDecl("Updated Heaps are Successor Heaps", {
-          val value = LocalVarDecl(Identifier("v"),TypeVar("B"));
-          val upd = MapUpdate(h.l,Seq(obj.l,field.l),value.l)
+          val value = LocalVarDecl(Identifier("v"), TypeVar("B"));
+          val upd = MapUpdate(h.l, Seq(obj.l, field.l), value.l)
           Axiom(Forall(
             Seq(h, obj, field, value),
             Trigger(Seq(upd))
@@ -233,7 +186,20 @@ class DefaultHeapModule(val verifier: Verifier)
             ,
             identicalFuncApp ==> FuncApp(succHeapName, Seq(h.l, eh.l), Bool)
           )), size = 1) ++
-            MaybeCommentedDecl("Successor Heaps are Transitive Successor Heaps", {
+        {
+          if (useSumOfStatesAxioms) {
+            MaybeCommentedDecl("IdenticalOnKnownLiberalLocations Heaps are Successor Heaps",
+              Axiom(Forall(
+                vars,
+                Trigger(Seq(identicalLiberalFuncApp))
+                ,
+                identicalLiberalFuncApp ==> FuncApp(succHeapName, Seq(h.l, eh.l), Bool)
+              )), size = 1)
+          } else {
+            Nil
+          }
+        } ++
+      MaybeCommentedDecl("Successor Heaps are Transitive Successor Heaps", {
               val succHeapApp = FuncApp(succHeapName, Seq(h0.l, h1.l), Bool)
               Axiom(Forall(
                 Seq(h0, h1),
@@ -251,9 +217,168 @@ class DefaultHeapModule(val verifier: Verifier)
             ,
             (succHeapTransApp && succHeapApp) ==> FuncApp(succHeapTransName, Seq(h0.l, h2.l), Bool) // NOTE: ignore IDE warning - these parentheses are NOT spurious, due to how the overloaded && and ==> get desugared
           ))
-        }, size = 1)
+        }, size = 1) ++
+        {
+          if (useSumOfStatesAxioms) {
+            identicalOnKnownLocsAxioms(true) ++
+              MaybeCommentedDecl("Sum of heaps", {
+                val mask1 = LocalVarDecl(Identifier("Mask1"),maskType)
+                val mask2 = LocalVarDecl(Identifier("Mask2"),maskType)
+
+                val sumStateApp = sumHeap(h.l, h1.l, mask1.l, h2.l, mask2.l)
+
+                Axiom(Forall(
+                  Seq(h, h1, mask1, h2, mask2),
+                  Trigger(sumStateApp),
+                  sumStateApp <==> (
+                    FuncApp(identicalOnKnownLocsLiberalName, Seq(h1.l, h.l, mask1.l), Bool) &&
+                      FuncApp(identicalOnKnownLocsLiberalName, Seq(h2.l, h.l, mask2.l), Bool)
+                    )))
+              })
+          } else {
+            Nil
+          }
+        }
+      }
     }
+
+  /* The liberal version does not equate the known-folded permission masks, but instead just propagates the information
+   * that known-folded locations remain known-folded (while locations that are not known-folded are underspecified).
+   * This permits taking the sum of two heaps that record different known-folded permission masks.
+   */
+  private def identicalOnKnownLocsAxioms(liberal: Boolean):Seq[Decl] = {
+    val obj = LocalVarDecl(Identifier("o")(axiomNamespace), refType)
+    val obj2 = LocalVarDecl(Identifier("o2")(axiomNamespace), refType)
+    val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
+    val predField = LocalVarDecl(Identifier("pm_f")(axiomNamespace),
+      predicateVersionFieldType("C"))
+    val h = LocalVarDecl(heapName, heapTyp)
+    val eh = LocalVarDecl(exhaleHeapName, heapTyp)
+    val vars = Seq(h, eh) ++ staticMask
+
+    val funcName = if (liberal) {
+      identicalOnKnownLocsLiberalName
+    } else {
+      identicalOnKnownLocsName
+    }
+
+    val identicalFuncApp = FuncApp(funcName, vars map (_.l), Bool)
+    // frame all locations with direct permission
+    MaybeCommentedDecl("Frame all locations with direct permissions", Axiom(Forall(
+      vars ++ Seq(obj, field),
+      //        Trigger(Seq(identicalFuncApp, lookup(h.l, obj.l, field.l))) ++
+      Trigger(Seq(identicalFuncApp, lookup(eh.l, obj.l, field.l))),
+      identicalFuncApp ==>
+        (staticPermissionPositive(obj.l, field.l) ==>
+          (lookup(h.l, obj.l, field.l) === lookup(eh.l, obj.l, field.l)))
+    )), size = 1) ++
+    {
+      // frame all predicate masks
+      if(!liberal) {
+        //equate permission mask maps
+        MaybeCommentedDecl("Frame all predicate mask locations of predicates with direct permission", Axiom(Forall(
+          vars ++ Seq(predField),
+          Trigger(Seq(identicalFuncApp, isPredicateField(predField.l), lookup(eh.l, nullLit, predicateMaskField(predField.l)))),
+          identicalFuncApp ==>
+            ((staticPermissionPositive(nullLit, predField.l) && isPredicateField(predField.l)) ==>
+              (lookup(h.l, nullLit, predicateMaskField(predField.l)) === lookup(eh.l, nullLit, predicateMaskField(predField.l))))
+        )), size = 1)
+      } else {
+        //just propagate information that heap location is known-folded, but not that it is not known-folded
+        MaybeCommentedDecl("Frame all predicate mask locations of predicates with direct permission. But don't propagate information " +
+          " of locations that are not known-folded to allow for equating with multiple different (but compatible) heaps",
+          Axiom(Forall( vars ++ Seq(predField),
+          Trigger(Seq(identicalFuncApp, isPredicateField(predField.l), lookup(eh.l, nullLit, predicateMaskField(predField.l)))),
+          identicalFuncApp ==>
+            ((staticPermissionPositive(nullLit, predField.l) && isPredicateField(predField.l)) ==>
+              Forall(Seq(obj2, field),
+                Trigger(Seq(lookup(lookup(eh.l, nullLit, predicateMaskField(predField.l)), obj2.l, field.l))),
+                (lookup(lookup(h.l, nullLit, predicateMaskField(predField.l)), obj2.l, field.l) ==>
+                  lookup(lookup(eh.l, nullLit, predicateMaskField(predField.l)), obj2.l, field.l),
+                ),
+                field.typ.freeTypeVars
+              )
+        ))), size = 1)
+      }
+     }  ++
+      // frame all locations with known folded permission
+      MaybeCommentedDecl("Frame all locations with known folded permissions", Axiom(Forall(
+        vars ++ Seq(predField),
+        //Trigger(Seq(identicalFuncApp, lookup(h.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
+        Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predField.l), isPredicateField(predField.l))) /*++
+          Trigger(Seq(identicalFuncApp, lookup(eh.l, nullLit, predicateMaskField(predField.l)), isPredicateField(predField.l))) ++
+          (verifier.program.predicates map (pred =>
+            Trigger(Seq(identicalFuncApp, predicateTriggerAnyState(pred, predField.l), isPredicateField(predField.l))))
+            )*/,
+        identicalFuncApp ==>
+          (
+            (staticPermissionPositive(nullLit, predField.l) && isPredicateField(predField.l)) ==>
+              Forall(Seq(obj2, field),
+                //Trigger(Seq(lookup(h.l, obj2.l, field.l))) ++
+                Trigger(Seq(lookup(eh.l, obj2.l, field.l))),
+                (lookup(lookup(h.l, nullLit, predicateMaskField(predField.l)), obj2.l, field.l) ==>
+                  (lookup(h.l, obj2.l, field.l) === lookup(eh.l, obj2.l, field.l))),
+                field.typ.freeTypeVars
+              )
+            )
+      )), size = 1)  ++ {
+      // frame all wand masks
+      if(!liberal) {
+        MaybeCommentedDecl("Frame all wand mask locations of wands with direct permission", Axiom(Forall(
+          vars ++ Seq(predField),
+          Trigger(Seq(identicalFuncApp, isWandField(predField.l), lookup(eh.l, nullLit, wandMaskField(predField.l)))),
+          identicalFuncApp ==>
+            ((staticPermissionPositive(nullLit, predField.l) && isWandField(predField.l)) ==>
+              (lookup(h.l, nullLit, wandMaskField(predField.l)) === lookup(eh.l, nullLit, wandMaskField(predField.l))))
+        )), size = 1)
+      } else {
+        MaybeCommentedDecl("Frame all wand mask locations of wands with direct permission (but don't propagate information" +
+          " about locations that are not known-folded)",
+          Axiom(Forall( vars ++ Seq(predField),
+          Trigger(Seq(identicalFuncApp, isWandField(predField.l), lookup(eh.l, nullLit, wandMaskField(predField.l)))),
+          identicalFuncApp ==>
+            ((staticPermissionPositive(nullLit, predField.l) && isWandField(predField.l)) ==>
+              Forall(Seq(obj2, field),
+                Trigger(Seq(lookup(lookup(eh.l, nullLit, wandMaskField(predField.l)), obj2.l, field.l))),
+                (lookup(lookup(h.l, nullLit, wandMaskField(predField.l)), obj2.l, field.l) ==>
+                  lookup(lookup(eh.l, nullLit, wandMaskField(predField.l)), obj2.l, field.l)
+                  ),
+                field.typ.freeTypeVars
+              )
+              )
+        )), size = 1)
+      }
+    } ++
+      MaybeCommentedDecl("Frame all locations in the footprint of magic wands", Axiom(Forall(
+        vars ++ Seq(predField),
+        Trigger(Seq(identicalFuncApp, isWandField(predField.l)))
+        ,
+        identicalFuncApp ==>
+          (
+            (staticPermissionPositive(nullLit, predField.l) && isWandField(predField.l)) ==>
+              Forall(Seq(obj2, field),
+                Trigger(Seq(lookup(eh.l, obj2.l, field.l))),
+                (lookup(lookup(h.l, nullLit, wandMaskField(predField.l)), obj2.l, field.l) ==>
+                  (lookup(h.l, obj2.l, field.l) === lookup(eh.l, obj2.l, field.l))),
+                field.typ.freeTypeVars
+              )
+            )
+      )), size = 1) ++
+      (if(enableAllocationEncoding) // preserve "allocated" knowledge, where already true
+        MaybeCommentedDecl("All previously-allocated references are still allocated", Axiom(Forall(
+          vars ++ Seq(obj),
+          /*Trigger(Seq(identicalFuncApp, lookup(h.l, obj.l, Const(allocName)))) ++*/
+          Trigger(Seq(identicalFuncApp, lookup(eh.l, obj.l, Const(allocName)))),
+          identicalFuncApp ==>
+            (lookup(h.l, obj.l, Const(allocName)) ==> lookup(eh.l, obj.l, Const(allocName)))
+        )), size = 1) else Nil)
   }
+
+  override def sumHeap(resultHeap: Exp, heap1: Exp, mask1: Exp, heap2: Exp, mask2: Exp): Exp = {
+    FuncApp(sumHeapName, Seq(resultHeap, heap1, mask1, heap2, mask2), Bool)
+  }
+
+  override def heapType: Type = heapTyp
 
   override def successorHeapState(first: Seq[LocalVarDecl], second: Seq[LocalVarDecl]): Exp = {
     FuncApp(succHeapTransName, (first ++ second) map (_.l), Bool)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -265,7 +265,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
         case Some(s) =>
           currentMethodIsAbstract = false
           val normalizedBody =
-            s.transformForceCopy(
+            s.transform(
               rewriteDummyStatements, sil.utility.rewriter.Traverse.BottomUp
             ).asInstanceOf[sil.Seqn]
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -1,0 +1,635 @@
+package viper.carbon.modules.impls
+
+import viper.carbon.modules.LoopModule
+import viper.silver.{ast => sil}
+import viper.carbon.boogie._
+import viper.carbon.verifier.Verifier
+import Implicits._
+import viper.carbon.modules.components.StmtComponent
+import viper.carbon.utility._
+import viper.silver.ast.utility.ViperStrategy
+import viper.silver.cfg.utility.{IdInfo, LoopDetector, LoopInfo}
+import viper.silver.verifier.{PartialVerificationError, errors}
+
+import scala.collection.mutable
+import scala.collection.mutable.Map
+import scala.collection.immutable.{Map => ImmutableMap}
+
+
+/**
+  * Info used to indicate that statement was solely added for having an AST that is easier to work with for the handling
+  * of loops. Thus, the statement can be ignored. It must be guaranteed that any statement containing this info object,
+  * does not change the meaning of the program even if it is not ignored ("inhale true" would, for example, be ok)
+  */
+case class LoopDummyStmtInfo() extends sil.Info {
+  override def comment: Seq[String] = Seq(toString)
+
+  override def isCached: Boolean = false
+}
+
+class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComponent {
+
+  import verifier._
+  import inhaleModule._
+  import exhaleModule._
+  import expModule._
+  import permModule._
+  import heapModule._
+
+  implicit val namespace = verifier.freshNamespace("loop")
+
+  //separate masks for each loop to store the permissions which are framed away
+  private var frames: Map[Int, (LocalVarDecl,LocalVarDecl)] = Map[Int, (LocalVarDecl, LocalVarDecl)]();
+
+  private var loopToInvs: Map[Int, Seq[sil.Exp]] = Map.empty
+  private var labelLoopInfoMap: Map[String, LoopInfo] = Map.empty
+  private var loopToWrittenVars: ImmutableMap[Int, Seq[sil.LocalVar]] = ImmutableMap.empty
+
+  private var nodeToCondLoopInfoOutput : Map[Int, Seq[LoopGenKind]] = Map.empty
+  private var nodeToLoopInfoOutput : Map[Int, Seq[LoopGenKind]] = Map.empty
+
+  private val sumMaskName : Identifier = Identifier("LoopSumMask")(namespace)
+  private val sumMask = LocalVar(sumMaskName, maskType)
+
+  private val sumHeapName : Identifier = Identifier("LoopSumHeap")(namespace)
+  private val sumHeap = LocalVar(sumHeapName, heapType)
+
+  private var currentMethodIsAbstract = false;
+  private var useLoopDetector = false;
+
+  override def start() = {
+    /* loopModule should be after all other modules, since it needs to output code that must be output before due to
+     * an incoming conditional edge or output after due to an outgoing unconditional edge. Furthermore, the loop module
+     * is responsible for handling gotos, which should also happen after the remaining code.
+     */
+    stmtModule.register(this, after = Seq(verifier.wandModule,verifier.heapModule,verifier.permModule, verifier.stmtModule))
+  }
+
+  override def initializeMethod(m: sil.Method): sil.Method = {
+    reset()
+
+    //only run the loop detector if the loop body has goto statements
+    val hasGotos =
+      m.body.fold(false)(body => body.existsDefined(
+        {
+          case _: sil.Goto => true
+        }
+      ))
+
+    if(hasGotos) {
+      useLoopDetector = true
+      initializeMethodWithGotos(m)
+    } else {
+      useLoopDetector = false
+      m
+    }
+  }
+
+  private def initializeMethodWithGotos(m: sil.Method): sil.Method = {
+    def isComposite(s: sil.Stmt): Boolean = {
+      s match {
+        case sil.Seqn(_, _) => true
+        case sil.If(_, _, _) => true
+        case sil.While(_, _, _) => true
+        case _ => false
+      }
+    }
+
+    def getFirstSimple(s: Seq[sil.Stmt]): Option[sil.Stmt] = {
+      if (s.isEmpty) {
+        None
+      } else {
+        Some(s(0))
+      }
+    }
+
+    def getDummyNode(): sil.Stmt = {
+      sil.Inhale(sil.TrueLit()(sil.NoPosition, sil.NoInfo, sil.NoTrafos))(sil.NoPosition, LoopDummyStmtInfo(), sil.NoTrafos)
+    }
+
+    def getLoopInfo(s: sil.Stmt) : Option[LoopInfo] = s.info.getUniqueInfo[LoopInfo]
+    def getIdInfo(s: sil.Stmt) : Option[IdInfo] = s.info.getUniqueInfo[IdInfo]
+
+    def updateMapSeq[K,V](m: mutable.Map[K, Seq[V]], key: K, value: Seq[V]): Unit = {
+      m.get(key) match {
+        case Some(vOld) => m.put(key, vOld ++ value)
+        case None => m.put(key, value)
+      }
+    }
+
+    def addLoopEdgeKind(stmtId: Int, value: Seq[LoopGenKind], conditionalJump: Boolean): Unit = {
+      if(value.nonEmpty) {
+        if(conditionalJump) {
+          updateMapSeq(nodeToCondLoopInfoOutput, stmtId, value)
+        } else {
+          updateMapSeq(nodeToLoopInfoOutput, stmtId, value)
+        }
+      }
+    }
+
+    /* Add dummy statements to the method body such that LoopDetector behaves properly. For example, this ensures that
+     * the first statement of branches in if-statements are non-composite.
+     */
+    val rewriteDummyStatements: PartialFunction[sil.Node, sil.Node] =
+      (node: sil.Node) =>
+        node match {
+          case seqStmt@sil.Seqn(stmts, decls) => {
+            val newStmts =
+              if(stmts.nonEmpty) {
+                stmts.foldRight(Seq.empty: Seq[sil.Stmt])((a, b) => {
+                  if (isComposite(a) && getFirstSimple(b).map(b => isComposite(b)).getOrElse(false)) {
+                    a +: getDummyNode() +: b
+                  } else {
+                    a +: b
+                  }
+                })
+              } else {
+                Seq(getDummyNode())
+              }
+
+            sil.Seqn(newStmts, decls)(seqStmt.pos, seqStmt.info, seqStmt.errT)
+          }
+          case ifStmt@sil.If(b, thn, els) => {
+            def getNewBranch(stmt: sil.Seqn): sil.Seqn = {
+              /**
+                * ensure that branch is 1) non-empty,
+                *                       2) first statement is not a composite statement
+                *                       3) first statement is not a label statement (to make sure that there is only one
+                *                       predecessor)
+                */
+              if (getFirstSimple(stmt.ss).map(firstStmt => isComposite(firstStmt) || firstStmt.isInstanceOf[sil.Label]).getOrElse(true)) {
+                sil.Seqn(getDummyNode() +: stmt.ss, stmt.scopedDecls)(stmt.pos, stmt.info, stmt.errT)
+              } else {
+                stmt
+              }
+            }
+
+            val newThn = getNewBranch(thn)
+            val newElse = getNewBranch(els)
+
+            sil.If(b, newThn, newElse)(ifStmt.pos, ifStmt.info, ifStmt.errT)
+          }
+          case whileStmt@sil.While(cond, invs, body) => {
+            //ensure that first and final statements in body are not composite.
+            val bodyLastOk =
+              if(isComposite(body.ss.last)) {
+                sil.Seqn(body.ss ++ Seq(getDummyNode()), body.scopedDecls)(body.pos, body.info, body.errT)
+              } else {
+                body
+              }
+
+            val bodyFirstOk =
+            if (getFirstSimple(bodyLastOk.ss).map(firstStmt => isComposite(firstStmt)).getOrElse(true)) {
+              sil.Seqn(getDummyNode() +: bodyLastOk.ss, bodyLastOk.scopedDecls)(bodyLastOk.pos, bodyLastOk.info, bodyLastOk.errT)
+            } else {
+              bodyLastOk
+            }
+            sil.While(cond, invs, bodyFirstOk)(whileStmt.pos, whileStmt.info, whileStmt.errT)
+          }
+        }
+
+
+    // gets the first basic statements in s, assuming that there are no empty sil.Seqn nodes
+    def getFirstBasicStmts(s: sil.Stmt, b: Boolean) : Seq[(Int, LoopInfo, Boolean)] = {
+      s match {
+        case sil.Seqn(ss, _) =>
+          getFirstBasicStmts(ss(0), b)
+        case sw@sil.While(_,_,_) =>
+          (getLoopInfo(sw), getIdInfo(sw)) match {
+            case (Some(loopInfo), Some(IdInfo(id))) =>
+              Seq((id, loopInfo, b))
+            case (_,_) => Seq.empty
+          }
+        case sil.If(_,thn,els) => getFirstBasicStmts(thn, true) ++ getFirstBasicStmts(els, true)
+        case basicStmt : sil.Stmt =>
+          (getLoopInfo(basicStmt), getIdInfo(basicStmt)) match {
+            case (Some(loopInfo), Some(IdInfo(id))) =>
+              Seq((id, loopInfo, b))
+            case (_,_) => Seq.empty
+          }
+        case _ => Seq.empty
+      }
+    }
+
+    //records for each basic statement all of its successor basic statements for which loop code must be generated
+    def captureRelevantNextStmts(s: sil.Stmt, l: Seq[(Int, LoopInfo, Boolean)]) : Unit = {
+      s match {
+        case sil.Seqn(ss, _) =>  {
+          ss.foldRight(l)( (a,b) => {
+            captureRelevantNextStmts(a,b)
+            val temp = getFirstBasicStmts(a, false)
+            temp
+          })
+        }
+        case sil.If(_, thn, els) => {
+          captureRelevantNextStmts(thn, l)
+          captureRelevantNextStmts(els, l)
+        }
+        case sil.While(_,_,body) => captureRelevantNextStmts(body, Seq.empty)
+        case goto@sil.Goto(target) =>
+          labelLoopInfoMap.get(target) match {
+            case Some(targetLoopInfo) => {
+              getIdInfo(goto) match {
+                case Some(IdInfo(id)) =>
+                  nodeToLoopInfoOutput.put(id, getLoopEdgeKind(getLoopInfo(goto), targetLoopInfo))
+                case None =>
+                  sys.error("Goto does not have a unique id")
+              }
+            }
+            case _ =>
+          }
+        case sourceStmt : sil.Stmt =>
+          if (l.nonEmpty) {
+              getIdInfo(sourceStmt) match {
+                case Some(IdInfo(sourceId)) =>
+                  l.foreach( a => {
+                    val (targetId, targetLoopInfo, conditionalJump) = a
+                    if(conditionalJump) {
+                      //target cannot have any other predecessors and we need to generate the code after the condition is evaluated
+                      addLoopEdgeKind(targetId, getLoopEdgeKind(getLoopInfo(sourceStmt), targetLoopInfo), true)
+                    } else {
+                      /* target may have other predecessors, but since it's an unconditional jump, we can generate code
+                         at the source
+                       */
+                      addLoopEdgeKind(sourceId, getLoopEdgeKind(getLoopInfo(sourceStmt), targetLoopInfo), false)
+                    }
+                  })
+                case None => sys.error("basic statement, for which next statement contains loop information does not have id")
+              }
+            }
+      }
+    }
+
+
+    val saved = ViperStrategy.forceRewrite
+    ViperStrategy.forceRewrite = true
+
+    val result =
+      m.body match {
+        case Some(s) =>
+          currentMethodIsAbstract = false
+          val normalizedBody =
+            s.transform(
+              rewriteDummyStatements, sil.utility.rewriter.Traverse.BottomUp
+            ).asInstanceOf[sil.Seqn]
+
+          val (loopInfoBody, loopToWrittenVarsResult) = LoopDetector.detect(normalizedBody, true, true)
+          loopToWrittenVars = loopToWrittenVarsResult.get
+          initializeMappings(loopInfoBody)
+          captureRelevantNextStmts(loopInfoBody, Seq())
+          m.copy(body = Some(loopInfoBody))(m.pos, m.info, m.errT)
+        case None =>
+          currentMethodIsAbstract = true
+          m
+      }
+
+    ViperStrategy.forceRewrite = saved
+
+    result
+  }
+
+  override def isLoopDummyStmt(stmt: sil.Stmt): Boolean =
+    stmt.info.getUniqueInfo[LoopDummyStmtInfo].nonEmpty
+
+  override def sumOfStatesAxiomRequired(): Boolean = useLoopDetector
+
+  private def relevantForLoops(s: sil.Stmt) : Boolean = {
+    s match {
+      case node@(_: sil.If | _: sil.Seqn) => false
+      case _ => true
+    }
+  }
+
+  private def initializeMappings(m: sil.Stmt) : Unit = {
+    loopToInvs = Map.empty
+    labelLoopInfoMap = Map.empty
+
+    def visit[N, A](n: N, subs: N => Seq[N], f: PartialFunction[N, A]): Unit =
+      sil.utility.Visitor.visit(n, subs)(f)
+
+    def updateInvariantMap(info: sil.Info, invs: Seq[sil.Exp]): Unit = {
+      info.getUniqueInfo[LoopInfo] match {
+        case Some(LoopInfo(Some(headId), _)) =>
+          loopToInvs = loopToInvs + (headId -> invs)
+        case _ =>
+      }
+    }
+
+    def updateLabelMap(labelName: String, info: sil.Info) = {
+      info.getUniqueInfo[LoopInfo] match {
+        case Some(loopInfo: LoopInfo) =>
+          labelLoopInfoMap = labelLoopInfoMap + (labelName -> loopInfo)
+        case None =>
+      }
+    }
+
+    val f: PartialFunction[sil.Node, Unit] = {
+      (stmt: sil.Node) =>
+        stmt match {
+          case sil.While(_, invs, _) =>
+            val (_, info, _) = stmt.meta
+            updateInvariantMap(info, invs)
+          case lbl@sil.Label(name, invs) =>
+            val (_, info, _) = stmt.meta
+            updateLabelMap(name, info)
+            if(lbl.info.getUniqueInfo[LoopInfo].fold(false)(loopInfo => loopInfo.head.nonEmpty)) {
+              updateInvariantMap(info, invs)
+            }
+        }
+    }
+
+    visit(m, sil.utility.Nodes.subnodes, f)
+  }
+
+  private def getLoopEdgeKind(sourceOpt: Option[LoopInfo], target: LoopInfo) : Seq[LoopGenKind] = {
+    val LoopInfo(targetHeadOpt, targetLoops) = target
+
+    val loopHeadKinds =
+    {
+      targetHeadOpt match {
+        case Some(headId) => {
+          //note that if sourceOpt = None, then this means the source loop information is the same as for the target
+          if (sourceOpt.fold(true)(source => source.loops.contains(headId))) {
+            Seq(Backedge(headId))
+          } else {
+            /** Since we currently eliminate all backedges, we can generate all the code necessary when jumping to a
+             * loop head right at the loop head. Thus, we need not record an "EnterLoop" edge here.
+             * If backedges were not eliminated, this would not work (since some part of the shared code should not be
+              * executed then, such as storing the mask in the frame after exhaling the invariant).
+             */
+            //Seq(EnterLoop(headId))
+            Seq()
+          }
+        }
+        case None => Seq()
+      }
+    }
+
+    var exitedLoops : Seq[Int] = Seq()
+    sourceOpt match {
+      case Some(LoopInfo(_, sourceLoops)) => {
+        sourceLoops.foreach {
+          (sourceLoopId: Int) =>
+            if (targetHeadOpt.fold(true)(targetHeadId => sourceLoopId != targetHeadId) && !targetLoops.contains(sourceLoopId)) {
+              //exiting loop
+              exitedLoops = sourceLoopId +: exitedLoops
+            }
+        }
+      }
+      case None =>
+    }
+
+    val result =
+      if(exitedLoops.nonEmpty) {
+        ExitLoops(exitedLoops) +: loopHeadKinds
+      } else {
+        loopHeadKinds
+      }
+
+    result
+  }
+
+  private def handleEdges(edgesKind: Seq[LoopGenKind]): Seq[Stmt] = {
+    edgesKind.foldRight[Seq[Stmt]](Seq())( (edgeKind, resultStmt) => {
+      edgeKind match {
+        case ExitLoops(loopIds) => exitLoops(loopIds) +: resultStmt
+        case Backedge(loopId) => backedgeJump(loopId) +: resultStmt
+        case BeforeEnterLoop(_) => sys.error("Unexpected edge kind")
+      }
+    })
+  }
+
+  /*
+   * return invariants and written variables of loop
+   */
+  private def getWhileInformation(w: sil.While): (Seq[sil.Exp], Seq[sil.LocalVar]) = {
+    if(useLoopDetector) {
+      w.info.getUniqueInfo[LoopInfo] match {
+        case Some(LoopInfo(Some(loopHeadId), _)) =>
+          val invs = getLoopInvariants(loopHeadId)
+          val writtenVars = getWrittenVariables(loopHeadId) diff (w.body.transitiveScopedDecls.collect { case l: sil.LocalVarDecl => l } map (_.localVar))
+          (invs, writtenVars)
+        case _ => sys.error("While loop is not a loop head")
+      }
+    } else {
+        val writtenVars = w.writtenVars diff (w.body.transitiveScopedDecls.collect {case l: sil.LocalVarDecl => l} map (_.localVar))
+        (w.invs, writtenVars)
+    }
+  }
+
+  private def handleWhile(w: sil.While): Stmt = {
+        val guard = translateExp(w.cond)
+        val (invs, writtenVars) = getWhileInformation(w)
+
+        beforeLoopHead(invs, w.info.getUniqueInfo[LoopInfo].map(loopInfo => loopInfo.head.get)) ++
+        MaybeCommentBlock("Havoc loop written variables (except locals)",
+          Havoc((writtenVars map translateExp).asInstanceOf[Seq[Var]]) ++
+            (writtenVars map (v => mainModule.allAssumptionsAboutValue(v.typ,mainModule.translateLocalVarSig(v.typ, v),false)))
+        ) ++
+        MaybeCommentBlock("Check definedness of invariant", NondetIf(
+          (invs map (inv => checkDefinednessOfSpecAndInhale(inv, errors.ContractNotWellformed(inv)))) ++
+            Assume(FalseLit())
+        )) ++
+        MaybeCommentBlock("Check the loop body", NondetIf({
+          val (freshStateStmt, prevState) = stateModule.freshTempState("loop")
+          val stmts = MaybeComment("Reset state", freshStateStmt ++ stateModule.initBoogieState) ++
+            MaybeComment("Inhale invariant", inhale(invs) ++ executeUnfoldings(invs, (inv => errors.Internal(inv)))) ++
+            Comment("Check and assume guard") ++
+            checkDefinedness(w.cond, errors.WhileFailed(w.cond)) ++
+            Assume(guard) ++ stateModule.assumeGoodState ++
+            MaybeCommentBlock("Translate loop body", stmtModule.translateStmt(w.body)) ++
+            MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
+            MaybeComment("Terminate execution", Assume(FalseLit()))
+          stateModule.replaceState(prevState)
+          stmts
+        }
+        )) ++
+        MaybeCommentBlock("Inhale loop invariant after loop, and assume guard",
+          Assume(guard.not) ++ stateModule.assumeGoodState ++
+            inhale(invs) ++ executeUnfoldings(invs, (inv => errors.Internal(inv)))
+        )
+  }
+
+  override def handleStmt(s: sil.Stmt, statesStackOfPackageStmt: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): (Seqn => Seqn) = {
+    if(useLoopDetector) {
+      handleStmtLoopDetector(s, statesStackOfPackageStmt, allStateAssms,insidePackageStmt)
+    } else {
+      inner =>
+        s match {
+          case w@sil.While(_,_,_) => inner ++ handleWhile(w)
+          case sil.Goto(_) => sys.error("Loop Module is incorrectly initialized: Goto is translated, but loop detector is not used")
+          case _ => inner
+        }
+    }
+  }
+
+  private def handleStmtLoopDetector(s: sil.Stmt, statesStackOfPackageStmt: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): (Seqn => Seqn) = {
+    inner => {
+      if (relevantForLoops(s)) {
+        val stmtId = s.info.getUniqueInfo[IdInfo]
+        stmtId match {
+          case Some(IdInfo(id)) => {
+            //code related to incoming edges
+            val incomingEdges = nodeToCondLoopInfoOutput.get(id).fold[Seq[Stmt]](Seq())(edgesKind => {
+              handleEdges(edgesKind)
+            })
+
+            //loop head code
+            val loopHead =
+              if (s.isInstanceOf[sil.While]) {
+                Seq(handleWhile(s.asInstanceOf[sil.While]))
+              } else {
+                s.info.getUniqueInfo[LoopInfo] match {
+                  case Some(LoopInfo(Some(loopId), _)) =>
+                    Seq(loopInit(loopId))
+                  case _ => Seq()
+                }
+              }
+
+            //code related to outgoing edges
+            val outgoingEdges = nodeToLoopInfoOutput.get(id).fold[Seq[Stmt]](Seq())(edgesKind => {
+              handleEdges(edgesKind)
+            })
+            val isBackedge = nodeToLoopInfoOutput.get(id).fold(false)(edgesKind => edgesKind.exists(edgeKind => edgeKind.isInstanceOf[Backedge]))
+
+            /* if statement is a goto, then it must be output at the end, otherwise code will not be reachable in Boogie
+     */
+            incomingEdges ++ inner ++ loopHead ++ outgoingEdges ++
+              (s match {
+                case sil.Goto(target) if !isBackedge => {
+                  Seq(Goto(Lbl(Identifier(target)(stmtModule.labelNamespace))))
+                }
+                case _ => Seq()
+              })
+          }
+          case None =>
+            /* This can occur whenever a statement is translated that was not part of the original body. */
+            inner
+        }
+      } else {
+        inner
+      }
+    }
+  }
+
+  private def loopInit(loopId: Int): Stmt = {
+    val invs : Seq[sil.Exp] = getLoopInvariants(loopId)
+    val writtenVars : Seq[sil.LocalVar] = getWrittenVariables(loopId)
+
+    //this sharing of code before loop head only works with backedge elimination with the current approach
+    beforeLoopHead(invs, Some(loopId)) ++
+    MaybeCommentBlock("Code for loop head " + loopId,
+      MaybeCommentBlock("Havoc loop written variables (except locals)",
+        Havoc((writtenVars map translateExp).asInstanceOf[Seq[Var]]) ++
+          (writtenVars map (v => mainModule.allAssumptionsAboutValue(v.typ, mainModule.translateLocalVarSig(v.typ, v), false)))
+      ) ++
+        MaybeCommentBlock("Check definedness of invariant", NondetIf(
+        (invs map (inv => checkDefinednessOfSpecAndInhale(inv, errors.ContractNotWellformed(inv)))) ++
+          Assume(FalseLit())
+      )) ++
+      MaybeCommentBlock("Check the loop body",
+        /** FIXME: here we change the state without resetting it
+            As long as modules the state at this point refers to the original state, this is fine.
+         */
+          MaybeComment("Reset state", stateModule.initBoogieState) ++
+          MaybeComment("Inhale invariant", inhale(invs) ++ executeUnfoldings(invs, (inv => errors.Internal(inv)))) ++
+          stateModule.assumeGoodState
+      )
+    )
+  }
+
+  private def backedgeJump(loopId: Int): Stmt = {
+    val invs : Seq[sil.Exp] = getLoopInvariants(loopId)
+    MaybeCommentBlock("Backedge to loop " + loopId,
+      MaybeCommentBlock("Check definedness of invariant", NondetIf(
+        (invs map (inv => checkDefinednessOfSpecAndInhale(inv, errors.ContractNotWellformed(inv)))) ++
+          Assume(FalseLit())
+      )) ++
+      MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
+        MaybeComment("Terminate execution", Assume(FalseLit()))
+    )
+  }
+
+  private def beforeLoopHead(invs: Seq[sil.Exp], loopIdOpt: Option[Int]): Stmt = {
+    MaybeCommentBlock("Before loop head" + loopIdOpt.fold("")(i => Integer.toString(i)),
+      MaybeCommentBlock("Exhale loop invariant before loop",
+        executeUnfoldings(invs, (inv => errors.LoopInvariantNotEstablished(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotEstablished(e))))
+      ) ++
+        loopIdOpt.fold(Nil:Stmt)(loopId => {
+          val (frameMask, frameHeap) = getFrame(loopId)
+          MaybeCommentBlock("Store frame in mask associated with loop",
+            Seq(Assign(frameMask.l, currentMask(0)),
+                Assign(frameHeap.l, currentHeap(0))
+            )
+          )
+        } )
+    )
+  }
+
+  private def exitLoops(loopIds: Seq[Int]): Stmt = {
+    if(loopIds.isEmpty) {
+      sys.error("Exit loop without any loop identifiers")
+    } else {
+      MaybeCommentBlock("Exiting loops " + loopIds.foldLeft("")((output, i) => output + ", " + i),
+        loopIds.foldLeft[Stmt](Nil)((curStmt, loopId) => {
+            val (frameMask, frameHeap) = getFrame(loopId)
+            curStmt ++
+              // sum masks and heaps
+              Seq(
+                Havoc(Seq(sumHeap)),
+                Havoc(Seq(sumMask)),
+                Assume(heapModule.sumHeap(sumHeap, currentHeap(0), currentMask(0), frameHeap.l, frameMask.l)),
+                Assign(currentHeap(0), sumHeap),
+                Assume(permModule.sumMask(Seq(sumMask), currentMask, Seq(frameMask.l))),
+                Assign(currentMask(0), sumMask),
+                stateModule.assumeGoodState
+              )
+          })
+      )
+    }
+  }
+
+  override def name: String = "Loop module"
+
+  override def reset(): Unit = {
+    frames = Map.empty
+    nodeToLoopInfoOutput = Map.empty
+    nodeToCondLoopInfoOutput = Map.empty
+    loopToInvs = Map.empty
+    loopToWrittenVars = ImmutableMap.empty
+    useLoopDetector = false
+  }
+
+  private def getFrame(loopId: Int): (LocalVarDecl, LocalVarDecl) = {
+    frames.get(loopId) match {
+      case Some(fMask) => fMask
+      case None => {
+        val freshMaskDecl = LocalVarDecl(Identifier("frameMask" + loopId), permModule.maskType)
+        val freshHeapDecl = LocalVarDecl(Identifier("frameHeap" + loopId), heapModule.heapType)
+        frames += (loopId -> (freshMaskDecl, freshHeapDecl))
+        (freshMaskDecl, freshHeapDecl)
+      }
+    }
+  }
+
+  private def getLoopInvariants(loopId: Int): Seq[sil.Exp] = {
+    loopToInvs.get(loopId) match {
+      case Some(invs) => invs
+      case None => sys.error("DefaultLoopModule: loop id " + loopId + " not registered")
+    }
+  }
+
+  private def getWrittenVariables(loopId: Int): Seq[sil.LocalVar] = {
+    loopToWrittenVars.get(loopId) match {
+      case Some(localVars) => localVars
+      case None => throw new RuntimeException("DefaultLoopModule: loop id is not registered")
+    }
+  }
+
+  //FIXME: duplicated from DefaultStmtModule
+  private def executeUnfoldings(exps: Seq[sil.Exp], exp_error: (sil.Exp => PartialVerificationError)): Stmt = {
+    (exps map (exp => (if (exp.existsDefined[Unit]({case sil.Unfolding(_,_) => })) checkDefinedness(exp, exp_error(exp), false) else Nil:Stmt)))
+  }
+
+}
+

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -260,16 +260,12 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
       }
     }
 
-
-    val saved = ViperStrategy.forceRewrite
-    ViperStrategy.forceRewrite = true
-
     val result =
       m.body match {
         case Some(s) =>
           currentMethodIsAbstract = false
           val normalizedBody =
-            s.transform(
+            s.transformForceCopy(
               rewriteDummyStatements, sil.utility.rewriter.Traverse.BottomUp
             ).asInstanceOf[sil.Seqn]
 
@@ -282,8 +278,6 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
           currentMethodIsAbstract = true
           m
       }
-
-    ViperStrategy.forceRewrite = saved
 
     result
   }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -111,22 +111,25 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
   }
 
   def translateMethodDecl(m: sil.Method, names: Option[mutable.Map[String, String]]): Seq[Decl] = {
-    env = Environment(verifier, m)
-    ErrorMemberMapping.currentMember = m
-        val res = m match {
+    //TODO
+    val mWithLoopInfo = loopModule.initializeMethod(m)
+
+    env = Environment(verifier, mWithLoopInfo)
+    ErrorMemberMapping.currentMember = mWithLoopInfo
+        val res = mWithLoopInfo match {
           case method @ sil.Method(name, formalArgs, formalReturns, pres, posts, _) =>
             val initOldStateComment = "Initializing of old state"
             val ins: Seq[LocalVarDecl] = formalArgs map translateLocalVarDecl
             val outs: Seq[LocalVarDecl] = formalReturns map translateLocalVarDecl
             val init = MaybeCommentBlock("Initializing the state", stateModule.initBoogieState ++ assumeAllFunctionDefinitions)
             val initOld = MaybeCommentBlock("Initializing the old state", stateModule.initOldState)
-            val paramAssumptions = m.formalArgs map (a => allAssumptionsAboutValue(a.typ, translateLocalVarDecl(a), true))
+            val paramAssumptions = mWithLoopInfo.formalArgs map (a => allAssumptionsAboutValue(a.typ, translateLocalVarDecl(a), true))
             val inhalePre = translateMethodDeclPre(pres)
             val checkPost: Stmt = if (posts.nonEmpty) {
               translateMethodDeclCheckPosts(posts)
             }
             else Nil
-            val postsWithErrors = posts map (p => (p, errors.PostconditionViolated(p, m)))
+            val postsWithErrors = posts map (p => (p, errors.PostconditionViolated(p, mWithLoopInfo)))
             val exhalePost = MaybeCommentBlock("Exhaling postcondition", exhale(postsWithErrors))
             val body: Stmt = translateStmt(method.bodyOrAssumeFalse)
               /* TODO: Might be worth special-casing on methods with empty bodies */

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -111,7 +111,6 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
   }
 
   def translateMethodDecl(m: sil.Method, names: Option[mutable.Map[String, String]]): Seq[Decl] = {
-    //TODO
     val mWithLoopInfo = loopModule.initializeMethod(m)
 
     env = Environment(verifier, mWithLoopInfo)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -41,7 +41,9 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
     // For New: the operation translation (HeapModule) is added as a prefix to the code adding permissions (PermModule)
   }
 
-  val lblNamespace = verifier.freshNamespace("stmt.lbl")
+  private val lblNamespace = verifier.freshNamespace("stmt.lbl")
+
+  override def labelNamespace = lblNamespace
 
   def name = "Statement module"
 
@@ -82,6 +84,11 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
     * For more details see the general node in 'wandModule'
     */
   override def simpleHandleStmt(stmt: sil.Stmt, statesStack: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): Stmt = {
+    if(loopModule.isLoopDummyStmt(stmt)) {
+      //statement was just added for loop information purposes (only loopModule cares about it)
+      return Nil
+    }
+
     stmt match {
       case assign@sil.LocalVarAssign(lhs, rhs) =>
         checkDefinedness(lhs, errors.AssignmentFailed(assign), insidePackageStmt = insidePackageStmt) ++
@@ -168,51 +175,26 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
           res
         }
         res
-      case w@sil.While(cond, invs, body) =>
-        val guard = translateExp(cond)
-        MaybeCommentBlock("Exhale loop invariant before loop",
-          executeUnfoldings(w.invs, (inv => errors.LoopInvariantNotEstablished(inv))) ++ exhale(w.invs map (e => (e, errors.LoopInvariantNotEstablished(e))))
-        ) ++ {
-          val writtenVars = w.writtenVars diff (body.transitiveScopedDecls.collect {case l: sil.LocalVarDecl => l} map (_.localVar))
-          MaybeCommentBlock("Havoc loop written variables (except locals)",
-            Havoc((writtenVars map translateExp).asInstanceOf[Seq[Var]]) ++
-              (writtenVars map (v => mainModule.allAssumptionsAboutValue(v.typ,mainModule.translateLocalVarSig(v.typ, v),false)))
-          )} ++
-          MaybeCommentBlock("Check definedness of invariant", NondetIf(
-            (invs map (inv => checkDefinednessOfSpecAndInhale(inv, errors.ContractNotWellformed(inv)))) ++
-              Assume(FalseLit())
-          )) ++
-          MaybeCommentBlock("Check the loop body", NondetIf({
-            val (freshStateStmt, prevState) = stateModule.freshTempState("loop")
-            val stmts = MaybeComment("Reset state", freshStateStmt ++ stateModule.initBoogieState) ++
-              MaybeComment("Inhale invariant", inhale(w.invs) ++ executeUnfoldings(w.invs, (inv => errors.Internal(inv)))) ++
-              Comment("Check and assume guard") ++
-              checkDefinedness(cond, errors.WhileFailed(w.cond)) ++
-              Assume(guard) ++ stateModule.assumeGoodState ++
-              MaybeCommentBlock("Translate loop body", translateStmt(body)) ++
-              MaybeComment("Exhale invariant", executeUnfoldings(w.invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhale(w.invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
-              MaybeComment("Terminate execution", Assume(FalseLit()))
-            stateModule.replaceState(prevState)
-            stmts
-          }
-          )) ++
-          MaybeCommentBlock("Inhale loop invariant after loop, and assume guard",
-            Assume(guard.not) ++ stateModule.assumeGoodState ++
-              inhale(w.invs) ++ executeUnfoldings(w.invs, (inv => errors.Internal(inv)))
-          )
+      case sil.While(_, _, _) =>
+        //handled by LoopModule
+        Nil
       case i@sil.If(cond, thn, els) =>
         checkDefinedness(cond, errors.IfFailed(cond), insidePackageStmt = insidePackageStmt) ++
         If((allStateAssms) ==> translateExpInWand(cond),
           translateStmt(thn, statesStack, allStateAssms, insidePackageStmt),
           translateStmt(els, statesStack, allStateAssms, insidePackageStmt))
-      case sil.Label(name, invs) => {
+      case sil.Label(name, _) => {
         val (stmt, currentState) = stateModule.freshTempState("Label" + name)
         stateModule.stateRepositoryPut(name, stateModule.state)
         stateModule.replaceState(currentState)
-        stmt ++ Label(Lbl(Identifier(name)(lblNamespace)))
+        /* stmt after label, otherwise the state at label won't capture (forward) jumps to this label
+         * if a labelled state is referred to w.r.t. a loop head, then it's not clear what the semantics should be
+         */
+        Label(Lbl(Identifier(name)(labelNamespace))) ++ stmt
       }
-      case sil.Goto(target) =>
-        Goto(Lbl(Identifier(target)(lblNamespace)))
+      case sil.Goto(_) =>
+        /* Handled by loop module, since the loop module decides whether the goto should be translated as a goto. */
+        Nil
       case pa@sil.Package(wand, proof) => {
         checkDefinedness(wand, errors.MagicWandNotWellformed(wand), insidePackageStmt = insidePackageStmt)
         translatePackage(pa, errors.PackageFailed(pa), statesStack, allStateAssms, insidePackageStmt)
@@ -235,7 +217,8 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
   override def translateStmt(stmt: sil.Stmt, statesStack: List[Any] = null, allStateAssms: Exp = TrueLit(), duringPackage: Boolean = false): Stmt = {
     if(duringPackage) {
         wandModule.translatingStmtsInWandInit()
-      }
+    }
+
     var comment = "Translating statement: " + stmt.toString.replace("\n", "\n  // ")
     stmt match {
       case sil.Seqn(ss, scopedDecls) =>
@@ -254,15 +237,6 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case _ =>
     }
 
-    def isComposite(stmt: sil.Stmt): Boolean = {
-      stmt match {
-        case _: sil.If => true
-        case _: sil.While => true
-        case _: sil.Seqn => true
-        case _ => false
-      }
-    }
-
     var stmts = Seqn(Nil)
     for (c <- components) { // NOTE: this builds up the translation inside-out, so the *first* component defines the innermost code.
       //      val (before, after) = c.handleStmt(stmt, statesStack, allStateAssms, inWand)
@@ -270,7 +244,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       val f = c.handleStmt(stmt, statesStack, allStateAssms, duringPackage)
       stmts = f(stmts)
     }
-    if (stmts.children.size == 0) {
+    if (stmts.children.size == 0 && !loopModule.isLoopDummyStmt(stmt)) {
       assert(assertion = false, "Translation of " + stmt + " is not defined")
     }
     val translation = stmts ::

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -76,7 +76,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   private val axiomNamespace = verifier.freshNamespace("perm.axiom")
   private val permTypeName = "Perm"
   private val maskTypeName = "MaskType"
-  private val maskType = NamedType(maskTypeName)
+  override val maskType = NamedType(maskTypeName)
   private val pmaskTypeName = "PMaskType"
   override val pmaskType = NamedType(pmaskTypeName)
   private val maskName = Identifier("Mask")
@@ -293,8 +293,11 @@ class QuantifiedPermModule(val verifier: Verifier)
     }
   }
 
-  def sumMask(summandMask1: Seq[Exp], summandMask2: Seq[Exp]): Exp =
+  override def sumMask(summandMask1: Seq[Exp], summandMask2: Seq[Exp]): Exp =
     FuncApp(sumMasks, currentMask++summandMask1++summandMask2,Bool)
+
+  override def sumMask(resultMask: Seq[Exp], summandMask1: Seq[Exp], summandMask2: Seq[Exp]): Exp =
+    FuncApp(sumMasks, resultMask++summandMask1++summandMask2,Bool)
 
   override def containsWildCard(e: sil.Exp): Boolean = {
     e match {

--- a/src/main/scala/viper/carbon/utility/LoopGenKind.scala
+++ b/src/main/scala/viper/carbon/utility/LoopGenKind.scala
@@ -1,0 +1,11 @@
+package viper.carbon.utility
+
+sealed trait LoopGenKind {
+
+}
+
+case class BeforeEnterLoop(loopId: Int) extends LoopGenKind
+
+case class ExitLoops(loopIds: Seq[Int]) extends LoopGenKind
+
+case class Backedge(loopId: Int) extends LoopGenKind

--- a/src/main/scala/viper/carbon/verifier/Verifier.scala
+++ b/src/main/scala/viper/carbon/verifier/Verifier.scala
@@ -33,6 +33,7 @@ trait Verifier {
   val setModule: SetModule
   val mapModule: MapModule
   val wandModule: WandModule
+  val loopModule: LoopModule
 
   /**
    * A list of all modules.
@@ -40,7 +41,7 @@ trait Verifier {
   lazy val allModules: Seq[Module] = {
     Seq(mainModule, stateModule, heapModule, permModule, stmtModule, expModule, typeModule,
       exhaleModule, inhaleModule, funcPredModule, domainModule, seqModule, setModule,
-      mapModule, wandModule)
+      loopModule, mapModule, wandModule)
   } ensuring {
     mods => true
   }


### PR DESCRIPTION
This PR adds support for loops formed via gotos (including jumps out of loops etc...). It relies on information from the Silver loop detector being added to the AST (developed on the ast-loops branch in the Silver repository).

The case when syntactic loops do not coincide with natural loops in the CFG has not been considered in detail. What the behaviour of such cases should be must be further investigated (for Viper programs in general).