### PR TITLE
Remove sumheap_bug.vpr from regressions (instead added it to tests in Silver)

### DIFF
--- a/src/test/resources/regression/sumheap_bug.vpr
+++ b/src/test/resources/regression/sumheap_bug.vpr
@@ -1,9 +1,0 @@
-method m1() {
-  while (true) {
-      goto bubble
-  }
-  label bubble
-}
-
-
-method m2() { }


### PR DESCRIPTION
sumheap_bug.vpr has been added in PR https://github.com/viperproject/silver/pull/591, so there's no need to keep it in the Carbon test folder (we usually keep all regression tests in the Silver repo, the Carbon repo regression tests are usually not included).