### PR TITLE
Well definedness checking order fixes

### DIFF
--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -21,14 +21,17 @@ trait DefinednessComponent extends Component {
   def freeAssumptions(e: sil.Exp): Stmt = Statements.EmptyStmt
 
   /**
-   * Well-definedness check for e itself (not its subnodes) that is emitted, before the well-definedness checks
-    * of e's subnodes are emitted. For more detail on "makeChecks" see [[partialCheckDefinedness]]
+    * Well-definedness check for `e` itself (not its subnodes). This check is invoked *before* invoking the
+    * well-definedness checks for `e`'s subnodes. The resulting Boogie encoding is also emitted *before* the encoding for
+    * the well-definedness checks for `e`'s subnodes.
+    * If `makeChecks` is set to false, then no definedness checks should be emitted. See [[partialCheckDefinedness]]
+    * for the purpose of `makeChecks`.
    */
   def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
 
   /**
-    * Same as [[simplePartialCheckDefinednessBefore]], except that the this well-definedness check is emitted *after* the
-    * well-definedness checks of e's subnodes are emitted
+    * Same as [[simplePartialCheckDefinednessBefore]], except that this well-definedness check is invoked and emitted
+    * *after* the well-definedness checks of `e`'s subnodes are invoked and emitted.
     */
   def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
 

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -24,10 +24,10 @@ trait DefinednessComponent extends Component {
    * Well-definedness check for e itself (not its subnodes) that is emitted, before the well-definedness checks
     * of e's subnodes are emitted. For more detail on "makeChecks" see [[partialCheckDefinedness]]
    */
-  def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
+  def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
 
   /**
-    * Same as [[simplePartialCheckDefinedness]], except that the this well-definedness check is emitted *after* the
+    * Same as [[simplePartialCheckDefinednessBefore]], except that the this well-definedness check is emitted *after* the
     * well-definedness checks of e's subnodes are emitted
     */
   def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
@@ -37,10 +37,10 @@ trait DefinednessComponent extends Component {
    * visiting all subexpressions, then all subexpressions are checked for definedness, and finally
    * the second part of the result is used.
    *
-   * The makeChecks argument can be set to false to cause the expression to be explored (and 
+   * The makeChecks argument can be set to false to cause the expression to be explored (and
    * corresponding unfoldings to be executed), but no other checks to actually be made. Note that this method
    * must be overridden for this parameter to be used.
    */
   def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): (() => Stmt, () => Stmt) =
-    (() => simplePartialCheckDefinedness(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
+    (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
 }

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -21,9 +21,16 @@ trait DefinednessComponent extends Component {
   def freeAssumptions(e: sil.Exp): Stmt = Statements.EmptyStmt
 
   /**
-   * Proof obligations for a given expression. See below for "makeChecks" description
+   * Well-definedness check for e itself (not its subnodes) that is emitted, before the well-definedness checks
+    * of e's subnodes are emitted. For more detail on "makeChecks" see [[partialCheckDefinedness]]
    */
   def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
+
+  /**
+    * Same as [[simplePartialCheckDefinedness]], except that the this well-definedness check is emitted *after* the
+    * well-definedness checks of e's subnodes are emitted
+    */
+  def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
 
   /**
    * Proof obligations for a given expression.  The first part of the result is used before
@@ -35,5 +42,5 @@ trait DefinednessComponent extends Component {
    * must be overridden for this parameter to be used.
    */
   def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): (() => Stmt, () => Stmt) =
-    (() => simplePartialCheckDefinedness(e, error, makeChecks), () => Statements.EmptyStmt)
+    (() => simplePartialCheckDefinedness(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -310,7 +310,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
     env.get(l)
   }
 
-  override def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
 
     val stmt: Stmt = (if (makeChecks)
       e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -752,7 +752,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           })} else () => Nil
         )
       }
-      case _ => (() => simplePartialCheckDefinedness(e, error, makeChecks), () => Nil)
+      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => Nil)
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -752,7 +752,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           })} else () => Nil
         )
       }
-      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => Nil)
+      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
@@ -83,7 +83,7 @@ class DefaultMapModule(val verifier: Verifier) extends MapModule with Definednes
     NamedType("Map", Seq(translateType(mapType.keyType), translateType(mapType.valueType)))
   }
 
-  override def simplePartialCheckDefinedness(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
     if (makeChecks) exp match {
       case sil.MapLookup(base, key) => {
         val containsExp = translateMapExp(sil.MapContains(key, base)(exp.pos, exp.info, exp.errT))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
@@ -110,7 +110,7 @@ class DefaultSeqModule(val verifier: Verifier)
   }
 
 
-  override def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
 
     if(makeChecks)
       e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -282,7 +282,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
   }
 
 
-  override def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
     if(makeChecks) {
       e match {
         case labelOld@sil.LabelledOld(_, labelName) =>

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -745,7 +745,7 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
           Nil
         }
         (before _, after _)
-      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => Nil)
+      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -745,7 +745,7 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
           Nil
         }
         (before _, after _)
-      case _ => (() => simplePartialCheckDefinedness(e, error, makeChecks), () => Nil)
+      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => Nil)
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -1473,7 +1473,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   // AS: this is a trick to avoid well-definedness checks for the outermost heap dereference in an AccessPredicate node (since it describes the location to which permission is provided).
   // The trick is somewhat fragile, in that it relies on the ordering of the calls to this method (but generally works out because of the recursive traversal of the assertion).
   private var allowLocationAccessWithoutPerm = false
-  override def simplePartialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
 
     val stmt: Stmt = if(makeChecks) (
       e match {


### PR DESCRIPTION
For various expressions, Carbon checks well-definedness in an unintuitive order that is not in-sync with Silicon. This pull request changes the order of checks in the following cases (the descriptions provide the new checking order):

* Division a/b: Definedness of a and b are checked before checking that b is non-zero.
* Modulo a mod b: Definedness of a and b are checked before checking that b is non-zero.
* Map and sequence lookup: Keys and indices are checked first before checking whether the key/index is in the sequence/map