### PR TITLE
Fix ShellCheck warnings and errors

### DIFF
--- a/carbon.sh
+++ b/carbon.sh
@@ -20,12 +20,12 @@ Z3_EXE="${Z3_EXE:-$BOOGIE_HOME/z3.exe}"
 export Z3_EXE
 export BOOGIE_EXE
 
-BASEDIR="$(realpath `dirname $0`)"
+BASEDIR="$(realpath "$(dirname "$0")")"
 
 CP_FILE="$BASEDIR/carbon_classpath.txt"
 
-if [ ! -f $CP_FILE ]; then
-    (cd $BASEDIR; sbt "export runtime:dependencyClasspath" | tail -n1 > $CP_FILE)
+if [ ! -f "$CP_FILE" ]; then
+    (cd "$BASEDIR"; sbt "export runtime:dependencyClasspath" | tail -n1 > "$CP_FILE")
 fi
 
-java -Xss30M -cp "`cat $CP_FILE`" viper.carbon.Carbon $@
+exec java -Xss30M -cp "$(cat "$CP_FILE")" viper.carbon.Carbon "$@"


### PR DESCRIPTION
Fix warnings and errors reported by [ShellCheck](https://www.shellcheck.net/):

```
> shellcheck carbon.sh 

In carbon.sh line 23:
BASEDIR="$(realpath `dirname $0`)"
                    ^----------^ SC2046 (warning): Quote this to prevent word splitting.
                    ^----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                             ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
BASEDIR="$(realpath $(dirname "$0"))"


In carbon.sh line 27:
if [ ! -f $CP_FILE ]; then
          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ ! -f "$CP_FILE" ]; then


In carbon.sh line 28:
    (cd $BASEDIR; sbt "export runtime:dependencyClasspath" | tail -n1 > $CP_FILE)
        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    (cd "$BASEDIR"; sbt "export runtime:dependencyClasspath" | tail -n1 > "$CP_FILE")


In carbon.sh line 31:
java -Xss30M -cp "`cat $CP_FILE`" viper.carbon.Carbon $@
                  ^------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                      ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.

Did you mean: 
java -Xss30M -cp "$(cat "$CP_FILE")" viper.carbon.Carbon $@

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```