### PR TITLE
Quasihavoc initial support

### DIFF
--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -16,8 +16,6 @@ import verifier.{BoogieDependency, BoogieInterface, Verifier}
 import java.io.{BufferedOutputStream, File, FileOutputStream, IOException}
 import viper.silver.frontend.{MissingDependencyException, NativeModel, VariablesModel}
 import viper.silver.reporter.Reporter
-import viper.silver.verifier.errors.Internal
-import viper.silver.verifier.reasons.FeatureUnsupported
 
 /**
  * The main class to perform verification of Viper programs.  Deals with command-line arguments, configuration
@@ -171,7 +169,6 @@ case class CarbonVerifier(override val reporter: Reporter,
       case Some(v) => sys.error("Invalid option: " + v)
     }
 
-    program.transform()
     val (tProg, translatedNames) = mainModule.translate(program, reporter)
     _translated = tProg
 

--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -8,7 +8,7 @@ package viper.carbon
 
 import boogie.{BoogieModelTransformer, Namespace}
 import modules.impls._
-import viper.silver.ast.{Program, Quasihavocall}
+import viper.silver.ast.{MagicWand, Program, Quasihavoc, Quasihavocall}
 import viper.silver.utility.Paths
 import viper.silver.verifier._
 import verifier.{BoogieDependency, BoogieInterface, Verifier}
@@ -146,11 +146,16 @@ case class CarbonVerifier(override val reporter: Reporter,
 
     val unsupportedFeatures : Seq[AbstractError] =
       program.shallowCollect(
-      n =>
-        n match {
-          case q: Quasihavocall => Internal(FeatureUnsupported(q, "Carbon does not support quasihavocall"))
-        }
-    )
+        n =>
+          n match {
+            case q: Quasihavocall =>
+               ConsistencyError("Carbon does not support quasihavocall", q.pos)
+              //Internal(FeatureUnsupported(q, "Carbon does not support quasihavocall"))
+            case q@Quasihavoc(_, MagicWand(_, _)) =>
+              ConsistencyError("Carbon does not support quasihavoc of magic wands", q.pos)
+              //Internal(FeatureUnsupported(q, "Carbon does not support quasihavoc of magic wands"))
+          }
+      )
 
     if(unsupportedFeatures.nonEmpty) {
       return Failure(unsupportedFeatures)

--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -149,11 +149,9 @@ case class CarbonVerifier(override val reporter: Reporter,
         n =>
           n match {
             case q: Quasihavocall =>
-               ConsistencyError("Carbon does not support quasihavocall", q.pos)
-              //Internal(FeatureUnsupported(q, "Carbon does not support quasihavocall"))
+              ConsistencyError("Carbon does not support quasihavocall", q.pos)
             case q@Quasihavoc(_, MagicWand(_, _)) =>
               ConsistencyError("Carbon does not support quasihavoc of magic wands", q.pos)
-              //Internal(FeatureUnsupported(q, "Carbon does not support quasihavoc of magic wands"))
           }
       )
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -11,15 +11,16 @@ import viper.silver.ast.utility.Expressions
 import viper.silver.{ast => sil}
 import viper.carbon.boogie._
 import viper.carbon.boogie.Implicits._
+
 import java.text.SimpleDateFormat
 import java.util.Date
-
 import viper.carbon.boogie.CommentedDecl
 import viper.carbon.boogie.Procedure
 import viper.carbon.boogie.Program
 import viper.carbon.verifier.Environment
 import viper.silver.verifier.{TypecheckerWarning, errors}
 import viper.carbon.verifier.Verifier
+import viper.silver.ast.Quasihavoc
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.reporter.{Reporter, WarningsDuringTypechecking}
 
@@ -69,6 +70,16 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
             }
             res
           }
+          case q@Quasihavoc(cond, res) =>
+            /* TODO */
+            res match {
+              case r : sil.FieldAccess =>
+                sil.If(cond.get,
+                  sil.Seqn(
+                    Seq(sil.Exhale(sil.FieldAccessPredicate(r, sil.CurrentPerm(r)())())()),
+                    Seq())(),
+                  sil.Seqn(Seq(), Seq())())()
+            }
         },
         Traverse.TopDown)
     )

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -73,24 +73,21 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
           case Quasihavoc(condOpt, res) =>
             val curPermVarDecl = sil.LocalVarDecl("ph_temp_123_", sil.Perm)()
             val curPermVar = curPermVarDecl.localVar
-            val inhaleExhalePermission =
+            val resourceCurPerm =
               res match {
                 case r : sil.FieldAccess =>
-                  Seq(
-                    sil.Exhale(sil.FieldAccessPredicate(r, curPermVar)())(),
-                    sil.Inhale(sil.FieldAccessPredicate(r, curPermVar)())()
-                  )
+                  sil.FieldAccessPredicate(r, curPermVar)()
                 case r: sil.PredicateAccess =>
-                  Seq(
-                    sil.Exhale(sil.PredicateAccessPredicate(r, curPermVar)())(),
-                    sil.Inhale(sil.PredicateAccessPredicate(r, curPermVar)())()
-                  )
+                  sil.PredicateAccessPredicate(r, curPermVar)()
               }
 
             val curPermInhExPermission =
               sil.Seqn(
                   sil.LocalVarAssign(curPermVar, sil.CurrentPerm(res)())() +:
-                    inhaleExhalePermission
+                    Seq(
+                      sil.Exhale(resourceCurPerm)(),
+                      sil.Inhale(resourceCurPerm)()
+                    )
                 ,
                 Seq(curPermVarDecl)
               )()

--- a/src/test/scala/viper/carbon/AllTests.scala
+++ b/src/test/scala/viper/carbon/AllTests.scala
@@ -20,7 +20,7 @@ import viper.silver.reporter.{NoopReporter, StdIOReporter}
 class AllTests extends SilSuite {
   override def testDirectories: Seq[String] = Vector(
     "local", "all", "quantifiedpermissions", "quantifiedpredicates", "quantifiedcombinations",
-    "wands", "examples", "termination", "refute"
+    "wands", "examples", "termination", "refute", "quasihavoc"
   )
 
   override def frontend(verifier: Verifier, files: Seq[Path]): Frontend = {


### PR DESCRIPTION
This PR adds initial support for quasihavoc statements to Carbon (see the corresponding Silver PR https://github.com/viperproject/silver/pull/612). Quasihavocs for fields and predicates are desugared into exhaling all the permission of the corresponding resource and inhaling the same permission. For all other quasihavocs, consistency errors are reported (this is global, if there is one such unsupported quasihavoc no method is verified; this is the main reason for using consistency errors).

The Silver submodule points to the newest commit in the Silver quasihavoc branch. We should merge this PR only once the Silver PR has been merged.