### PR TITLE
Syntax for backend types

### DIFF
--- a/src/main/scala/viper/carbon/Carbon.scala
+++ b/src/main/scala/viper/carbon/Carbon.scala
@@ -28,6 +28,8 @@ class CarbonFrontend(override val reporter: Reporter,
 
   private var carbonInstance: CarbonVerifier = _
 
+  override def backendTypeFormat: Option[String] = Some("Boogie")
+
   def createVerifier(fullCmd: String) = {
     carbonInstance = CarbonVerifier(reporter, Seq("Arguments: " -> fullCmd))
 

--- a/src/main/scala/viper/carbon/modules/FuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/FuncPredModule.scala
@@ -63,5 +63,5 @@ trait FuncPredModule extends Module {
 
 
   def translateBackendFuncApp(fa: sil.BackendFuncApp): Exp
-  def translateBackendFunc(f: sil.BackendFunc): Seq[Decl]
+  def translateBackendFunc(f: sil.DomainFunc): Seq[Decl]
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
@@ -31,7 +31,7 @@ class DefaultDomainModule(val verifier: Verifier) extends DomainModule with Stat
   def outputName(domain: sil.Domain) : String = domain.name + "DomainType"
 
   override def translateDomain(domain: sil.Domain): Seq[Decl] = {
-    val fs = domain.functions flatMap translateDomainFunction
+    val fs = domain.functions.filter(f => f.interpretation.isEmpty) flatMap translateDomainFunction
     val as = domain.axioms flatMap translateDomainAxiom
     val ts = CommentedDecl(s"The type for domain ${domain.name}",
       TypeDecl(NamedType(this.outputName(domain) , domain.typVars map (tv => TypeVar(tv.name)))), size = 1)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -73,9 +73,9 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
         Traverse.TopDown)
     )
 
-    val backendFuncs = new mutable.HashSet[sil.BackendFunc]()
-    p.visit{
-      case sf: sil.BackendFuncApp => backendFuncs.add(sf.backendFunc)
+    val backendFuncs = new mutable.HashSet[sil.DomainFunc]()
+    for (d <- p.domains) {
+      backendFuncs.addAll(d.functions.filter(f => f.interpretation.isDefined))
     }
 
     // We record the Boogie names of all Viper variables in this map.

--- a/src/main/scala/viper/carbon/modules/impls/DefaultTypeModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultTypeModule.scala
@@ -49,7 +49,7 @@ class DefaultTypeModule(val verifier: Verifier) extends TypeModule with Stateles
         TypeVar(name)
       case t@sil.DomainType(_, _) =>
         translateDomainTyp(t)
-      case sil.BackendType(boogieName, _) if boogieName != null => NamedType(boogieName)
+      case sil.BackendType(_, interpretations) if interpretations.contains("Boogie") => NamedType(interpretations("Boogie"))
       case sil.BackendType(_, _) => sys.error("Found non-Boogie-compatible backend type.")
       case _ => sys.error("Viper type didn't match any existing case.")
     }

--- a/src/main/scala/viper/carbon/verifier/Environment.scala
+++ b/src/main/scala/viper/carbon/verifier/Environment.scala
@@ -27,19 +27,19 @@ case class Environment(verifier: Verifier, member: sil.Node) {
 
   // register types from member
   member match {
-    case sil.Method(name, args, returns, pres, posts, body) =>
+    case sil.Method(_, args, returns, _, _, _) =>
       for (v <- args ++ returns) {
         define(v.localVar)
       } 
-    case f@sil.Function(name, args, typ, pres, posts, exp) =>
+    case f@sil.Function(_, args, _, _, _, _) =>
       for (v <- args) {
         define(v.localVar)
       }
-    case sil.Predicate(name, args, body) =>
+    case sil.Predicate(_, args, _) =>
       for (v <- args) {
         define(v.localVar)
       }
-    case f@sil.DomainFunc(name, args, typ, unique) =>
+    case f@sil.DomainFunc(_, args, _, _, _) =>
       for (v <- args) {
         v match {
           case n: sil.LocalVarDecl => define(n.localVar)


### PR DESCRIPTION
Adapting to changes made in Silver PR 638 (https://github.com/viperproject/silver/pull/638):
Domains and Domain Functions can now have attached interpretations. DomainFuncs with attached interpretations replace the existing BackendFunc AST node.

That means:
- We distinguish between interpreted and uninterpreted domains and domain functions, and treat the former like existing BackendFuncs, and only the latter like normal domains and domain functions.
- The CarbonFrontend declares its backend name (Boogie) to enable consistency checks that ensure that the verified program has interpretations compatible with Carbon.