### PR TITLE
Consistent division and modulo

### DIFF
--- a/src/main/scala/viper/carbon/boogie/Optimizer.scala
+++ b/src/main/scala/viper/carbon/boogie/Optimizer.scala
@@ -103,9 +103,15 @@ object Optimizer {
      // This case was removed - the evaluation as doubles and translation of RealLit can introduce rounding/precision errors
      /* case BinExp(IntLit(left), Div, IntLit(right)) if right != 0 =>
         RealLit(left.toDouble / right.toDouble)*/
-      case BinExp(IntLit(left), IntDiv, IntLit(right)) if right != 0 =>
+
+      /* In the general case, Carbon uses the SMT division and modulo. Scala's division is not in-sync with SMT division.
+         For nonnegative dividends and divisors, all used division and modulo definitions coincide. So, in order to not
+         not make any assumptions on the SMT division, division and modulo are simplified only if the dividend and divisor
+         are nonnegative.
+       */
+      case BinExp(IntLit(left), IntDiv, IntLit(right)) if left >= 0 && right > 0 =>
         IntLit(left / right)
-      case BinExp(IntLit(left), Mod, IntLit(right)) if right != 0 =>
+      case BinExp(IntLit(left), Mod, IntLit(right)) if left >= 0 && right > 0 =>
         IntLit(left % right)
 
       case BinExp(RealLit(left), GeCmp, RealLit(right)) =>


### PR DESCRIPTION
Previously, Carbon always evaluated integer division and modulo using Scala if the divisor and dividend were integer literals (and the divisor is non-zero). If the  divisor or the dividend are not integer literals, then Carbon uses Boogie's division, which uses the SMT division. Scala's division differs from the SMT division and so this leads to inconsistencies.

This pull request simplifies integer division and modulo only if the divisor and dividend are nonnegative (and the divisor is nonzero), which removes this inconsistency.

This issue was already reported in https://github.com/viperproject/silver/issues/297. 