### PR TITLE
Renames QuantifierWeightTests to avoid a name clash with Silicon

### DIFF
--- a/src/test/scala/viper/carbon/CarbonQuantifierWeightTests.scala
+++ b/src/test/scala/viper/carbon/CarbonQuantifierWeightTests.scala
@@ -13,7 +13,7 @@ import viper.silver.ast.{Add, AnonymousDomainAxiom, Domain, DomainFunc, DomainFu
 import viper.silver.reporter.NoopReporter
 import viper.silver.verifier.{Failure, Success}
 
-class QuantifierWeightTests extends AnyFunSuite with BeforeAndAfterAll {
+class CarbonQuantifierWeightTests extends AnyFunSuite with BeforeAndAfterAll {
   val carbon: CarbonVerifier = CarbonVerifier(NoopReporter)
 
   override def beforeAll() {


### PR DESCRIPTION
Assembling a fat JAR containing our tests currently fails in ViperServer because Carbon and Silicon both have a class `QuantifierWeightTests`. This PR address this issue by making the test classes' names unique.