### PR TITLE
Refactor well-definedness of field acesses and permission division

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -393,8 +393,8 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
           val stmt = checks map (_._1())
 
           // AS: note that some implementations of the definedness checks rely on the order of these calls (i.e. parent nodes are checked before children, and children *are* always checked after parents.
-          val stmt2 = for (sub <- expSubnodesForDefinedness(e) if sub.isInstanceOf[sil.Exp]) yield {
-            checkDefinednessImpl(sub.asInstanceOf[sil.Exp], error, makeChecks = makeChecks)
+          val stmt2 = for (sub <- subexpressionsForDefinedness(e)) yield {
+            checkDefinednessImpl(sub, error, makeChecks = makeChecks)
           }
           val stmt3 = checks map (_._2())
 
@@ -459,13 +459,13 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
   }
 
   /***
-    * Returns subnodes that are relevant for definedness checks
+    * Returns subexpressions that are relevant for definedness checks
     */
-  private def expSubnodesForDefinedness(e: sil.Exp) : Seq[sil.Node] = {
+  private def subexpressionsForDefinedness(e: sil.Exp) : Seq[sil.Exp] = {
     e match {
-      case sil.AccessPredicate(res, perm) if res.isInstanceOf[sil.LocationAccess] => res.subnodes ++ Seq(perm)
-      case sil.CurrentPerm(res) if res.isInstanceOf[sil.LocationAccess] => res.subnodes
-      case _ => e.subnodes
+      case sil.AccessPredicate(res : sil.LocationAccess, perm) => res.subExps ++ Seq(perm)
+      case sil.CurrentPerm(res: sil.LocationAccess) => res.subExps
+      case _ => e.subExps
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -463,7 +463,8 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
     */
   private def expSubnodesForDefinedness(e: sil.Exp) : Seq[sil.Node] = {
     e match {
-      case sil.AccessPredicate(loc, perm) if loc.isInstanceOf[sil.LocationAccess] => loc.subnodes ++ Seq(perm)
+      case sil.AccessPredicate(res, perm) if res.isInstanceOf[sil.LocationAccess] => res.subnodes ++ Seq(perm)
+      case sil.CurrentPerm(res) if res.isInstanceOf[sil.LocationAccess] => res.subnodes
       case _ => e.subnodes
     }
   }


### PR DESCRIPTION
Now, the well-definedness of a field access first checks the well-definedness of a receiver and only afterwards checks whether there is enough permission (previously the order was reversed). Now, the well-definedness of a permission division first checks the well-definedness of the dividend and the divisor and only afterwards checks the whether the divisor is nonzero (before the order was reversed).

In the case of acc(e.f) and perm(e.f) (“PermAccess case”), the well-definedness check for e.f need not be checked. In all other cases (“NonPermAccess case”) such as “x := e.f”, the well-definedness check requires a permission check. In both cases, e.f is represented by the same AST subnode. Previously, Carbon differentiated the two cases in the well-definedness check with global state in a fragile way that relied on the fact that for the “NonPermAccess case” permission to e.f was checked before well-definedness of e was checke. Now, Carbon does not use global state for this differentiation (which then allowed me to also change the order of the checks).  Instead, the expression module (responsible for orchestrating the definedness checks) makes sure that the components contributing to the definedness check never obtain field accesses as an input for which no definedness check is required.