### PR TITLE
Mitigate a linear scan in translateDomainFuncApp

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
@@ -68,7 +68,11 @@ class DefaultDomainModule(val verifier: Verifier) extends DomainModule with Stat
   }
 
   override def translateDomainFuncApp(fa: sil.DomainFuncApp): Exp = {
-    val funct = verifier.program.findDomainFunction(fa.funcname)
+    val domain = verifier.program.findDomain(fa.domainName)
+    val funct = domain.functions.find(_.name == fa.funcname) match {
+      case Some(f) => f
+      case None => sys.error("Domain function " + fa.funcname + " not found in domain " + domain.name)
+    }
     if (funct.unique) {
       Const(Identifier(funct.name))
     } else {


### PR DESCRIPTION
This replaces a linear scan over *all functions* of *all domains* with two (much) smaller linear scans. The best solution would be to index all defined domain functions using hashmaps, e.g. in Carbon at the beginning of the translation or somehow in the Silver AST nodes.

See also: https://github.com/viperproject/silver/issues/657, https://github.com/viperproject/carbon/issues/453