### PR TITLE
Include definedness checks during exhale

### DIFF
--- a/src/main/scala/viper/carbon/modules/ExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExhaleModule.scala
@@ -59,10 +59,3 @@ trait ExhaleModule extends Module with ExhaleComponent with ComponentRegistry[Ex
   }
 
 }
-
-case class DefinednessCheckData(definednessError: PartialVerificationError, definednessState: Option[DefinednessState])
-
-object DefinednessCheckData {
-  def createWithoutState(definednessError: PartialVerificationError) = DefinednessCheckData(definednessError, None)
-
-}

--- a/src/main/scala/viper/carbon/modules/ExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExhaleModule.scala
@@ -25,7 +25,10 @@ import viper.silver.verifier.PartialVerificationError
 trait ExhaleModule extends Module with ExhaleComponent with ComponentRegistry[ExhaleComponent] {
 
   /**
-    * @param exp         the expression to be exhaled and the error to be raised if the exhale fails.
+    * @param exp         A sequence of triples where the conjunction of the corresponding expressions (projection on the
+    *                    the first element) is to be exhaled. The triple includes the error to be raised if the exhale fails and
+    *                    the error to be raised if a well-definedness check fails during the exhale (if the latter is set
+    *                    to [[None]], then no well-definedness checks are performed).
     * @param havocHeap   A boolean used to allow or prevent havocing the heap after the exhale.
     *                    For example, the heap is not havoced after the exhale when translating a fold statement.
     * @param isAssert    A boolean that tells whether the exhale method is being called during an exhale statement or an assert statement
@@ -42,6 +45,7 @@ trait ExhaleModule extends Module with ExhaleComponent with ComponentRegistry[Ex
              isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt
 
   /** convenience methods */
+
   def exhaleWithoutDefinedness(exp: Seq[(sil.Exp, PartialVerificationError)], havocHeap: Boolean = true,
                                isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt = {
     exhale(exp.map(eError => (eError._1, eError._2, None)), havocHeap = havocHeap, isAssert = isAssert, statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)

--- a/src/main/scala/viper/carbon/modules/ExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExhaleModule.scala
@@ -6,7 +6,7 @@
 
 package viper.carbon.modules
 
-import components.{ComponentRegistry, ExhaleComponent}
+import components.{ComponentRegistry, DefinednessState, ExhaleComponent}
 import viper.silver.{ast => sil}
 import viper.carbon.boogie.Stmt
 import viper.silver.verifier.PartialVerificationError
@@ -38,6 +38,31 @@ trait ExhaleModule extends Module with ExhaleComponent with ComponentRegistry[Ex
     * The 'statesStackForPackageStmt' and 'insidePackageStmt' are used when translating statements during packaging a wand.
     * For more details refer to the note in the wand module.
     */
-  def exhale(exp: Seq[(sil.Exp, PartialVerificationError)], havocHeap: Boolean = true, isAssert: Boolean = false
-             , statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt
+  def exhale(exp: Seq[(sil.Exp, PartialVerificationError, Option[PartialVerificationError])], havocHeap: Boolean = true,
+             isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt
+
+  /** convenience methods */
+  def exhaleWithoutDefinedness(exp: Seq[(sil.Exp, PartialVerificationError)], havocHeap: Boolean = true,
+                               isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt = {
+    exhale(exp.map(eError => (eError._1, eError._2, None)), havocHeap = havocHeap, isAssert = isAssert, statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)
+  }
+
+  def exhaleSingleWithoutDefinedness(exp: sil.Exp, exhaleError: PartialVerificationError, havocHeap: Boolean = true,
+                                     isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt = {
+    exhale(Seq((exp, exhaleError, None)), havocHeap = havocHeap, isAssert = isAssert, statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)
+  }
+
+  def exhaleSingleWithDefinedness(exp: sil.Exp, exhaleError: PartialVerificationError, definednessError: PartialVerificationError,
+                                  havocHeap: Boolean = true, isAssert: Boolean = false, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false) = {
+    exhale(Seq((exp, exhaleError, Some(definednessError))), havocHeap = havocHeap, isAssert = isAssert,
+      statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)
+  }
+
+}
+
+case class DefinednessCheckData(definednessError: PartialVerificationError, definednessState: Option[DefinednessState])
+
+object DefinednessCheckData {
+  def createWithoutState(definednessError: PartialVerificationError) = DefinednessCheckData(definednessError, None)
+
 }

--- a/src/main/scala/viper/carbon/modules/ExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExpModule.scala
@@ -8,7 +8,7 @@ package viper.carbon.modules
 
 import viper.silver.{ast => sil}
 import viper.carbon.boogie.{Exp, LocalVar, Stmt}
-import viper.carbon.modules.components.{ComponentRegistry, DefinednessComponent}
+import viper.carbon.modules.components.{ComponentRegistry, DefinednessComponent, DefinednessState}
 import viper.silver.verifier.PartialVerificationError
 
 /**
@@ -42,6 +42,7 @@ trait ExpModule extends Module with ComponentRegistry[DefinednessComponent] {
       * inWand distinguish when check definedness is called during a package statement.
       */
   def checkDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean = true,
+                       definednessState: Option[DefinednessState] = None,
                        insidePackageStmt: Boolean = false, ignoreIfInWand: Boolean = false): Stmt
 
   /**

--- a/src/main/scala/viper/carbon/modules/ExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExpModule.scala
@@ -30,31 +30,27 @@ trait ExpModule extends Module with ComponentRegistry[DefinednessComponent] {
    */
   def allFreeAssumptions(e: sil.Exp): Stmt
 
-    /**
-      * Check definedness of Viper expressions as they occur in the program.
-      *
-      * makeChecks provides the possibility of switching off most checks, to get
-      * only the side-effects (unfoldings) of unravelling the expression. Note that
-      * the parameter should be passed down through recursive calls (default true)
-      *
-      * ignoreIfInWand gives the option to ignore the definedness check if it is called during a package statement
-      *
-      * inWand distinguish when check definedness is called during a package statement.
-      */
+  /***
+    * Check well-definedness of Viper expressions. This method should only be invoked on pure Viper expressions or
+    * impure *atomic* Viper assertions (i.e., accessibility predicates, quantified permissions, magic wands).
+    * For other kinds of impure assertions such as separating conjunctions where one conjunct is impure, well-definedness
+    * is always tied to an inhale or exhale (or assert) operation. In those cases, the corresponding inhale and exhale
+    * methods should be invoked (the methods should permit switching on well-definedness checks).
+    *
+    * @param e
+    * @param error
+    * @param makeChecks provides the possibility of switching off most checks, to get only the side-effects (unfoldings)
+    *                   of unravelling the expression. Note that the parameter should be passed down through recursive
+    *                   calls (default true)
+    * @param definednessStateOpt If defined, then represents the state in which permission checks that are part of the definedness
+    *                            check should be made, otherwise these checks should be made in the currently active state.
+    *                            Expressions should be evaluated in the currently active state.
+    * @param insidePackageStmt true if call is made during a package statement
+    * @param ignoreIfInWand gives the option to ignore the definedness check if it is called during a package statement
+    * @return
+    */
   def checkDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean = true,
-                       definednessState: Option[DefinednessState] = None,
+                       definednessStateOpt: Option[DefinednessState] = None,
                        insidePackageStmt: Boolean = false, ignoreIfInWand: Boolean = false): Stmt
 
-  /**
-   * Check definedness of Viper assertions such as pre-/postconditions or invariants.
-   * The implementation works by exhaling 'e' and checking the necessary properties
-   * along the way.
-   *
-   * statesStackForPackageStmt stack of states used in translating statements during packaging a wand (carries currentState and LHS of wands)
-   * insidePackageStmt      Boolean that represents whether this method is being called during packaging a wand or not.
-   * The 'statesStackForPackageStmt' and 'insidePackageStmt' are used when translating statements during packaging a wand.
-   * For more details refer to the general note in 'wandModule'.
-   */
-  def checkDefinednessOfSpecAndExhale(e: sil.Exp, definednessError: PartialVerificationError, exhaleError: PartialVerificationError,
-                                      statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt
 }

--- a/src/main/scala/viper/carbon/modules/ExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExpModule.scala
@@ -35,7 +35,7 @@ trait ExpModule extends Module with ComponentRegistry[DefinednessComponent] {
     * impure *atomic* Viper assertions (e.g., accessibility predicates, quantified permissions).
     * For other kinds of impure assertions such as separating conjunctions where one conjunct is impure, well-definedness
     * is always tied to an inhale or exhale (or assert) operation. In those cases, the corresponding inhale and exhale
-    * methods should be invoked (the methods should permit switching on well-definedness checks).
+    * methods should be invoked, which permit switching on well-definedness checks.
     *
     * @param e
     * @param error

--- a/src/main/scala/viper/carbon/modules/ExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExpModule.scala
@@ -32,7 +32,7 @@ trait ExpModule extends Module with ComponentRegistry[DefinednessComponent] {
 
   /***
     * Check well-definedness of Viper expressions. This method should only be invoked on pure Viper expressions or
-    * impure *atomic* Viper assertions (i.e., accessibility predicates, quantified permissions, magic wands).
+    * impure *atomic* Viper assertions (e.g., accessibility predicates, quantified permissions).
     * For other kinds of impure assertions such as separating conjunctions where one conjunct is impure, well-definedness
     * is always tied to an inhale or exhale (or assert) operation. In those cases, the corresponding inhale and exhale
     * methods should be invoked (the methods should permit switching on well-definedness checks).

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -26,10 +26,9 @@ trait DefinednessComponent extends Component {
     * the well-definedness checks for `e`'s subnodes.
     * If `makeChecks` is set to false, then no definedness checks should be emitted. See [[partialCheckDefinedness]]
     * for the purpose of `makeChecks`.
-    * The currently active state represents the state in which expressions should be evaluated.
-    * If `definednessStateOpt` is defined, then it represents the state in which definedness checks
-    * should be made (i.e., where permissions should be checked) and otherwise the definedness state is given by the
-    * currently active state.
+    * If `definednessStateOpt` is defined, then it represents the state in which permission checks that are part of the
+    * definedness check should be made, otherwise these checks should be done in the currently active state.
+    * Expressions should be evaluated in the currently active state.
    */
   def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
                                           definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
@@ -49,6 +48,9 @@ trait DefinednessComponent extends Component {
    * The makeChecks argument can be set to false to cause the expression to be explored (and
    * corresponding unfoldings to be executed), but no other checks to actually be made. Note that this method
    * must be overridden for this parameter to be used.
+   * If `definednessStateOpt` is defined, then it represents the state in which permission checks that are part of the
+   * definedness check should be made, otherwise these checks should be done in the currently active state.
+   * Expressions should be evaluated in the currently active state.
    */
   def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
                               definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) =

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -54,4 +54,4 @@ trait DefinednessComponent extends Component {
     )
 }
 
-case class DefinednessState(setDefState: () => Unit)
+case class DefinednessState(var setDefState: () => Unit)

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -27,13 +27,15 @@ trait DefinednessComponent extends Component {
     * If `makeChecks` is set to false, then no definedness checks should be emitted. See [[partialCheckDefinedness]]
     * for the purpose of `makeChecks`.
    */
-  def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
+  def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
+                                          definednessState: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
     * Same as [[simplePartialCheckDefinednessBefore]], except that this well-definedness check is invoked and emitted
     * *after* the well-definedness checks of `e`'s subnodes are invoked and emitted.
     */
-  def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = Statements.EmptyStmt
+  def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
+                                        definednessState: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
    * Proof obligations for a given expression.  The first part of the result is used before
@@ -44,6 +46,12 @@ trait DefinednessComponent extends Component {
    * corresponding unfoldings to be executed), but no other checks to actually be made. Note that this method
    * must be overridden for this parameter to be used.
    */
-  def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): (() => Stmt, () => Stmt) =
-    (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
+  def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
+                             definednessState: Option[DefinednessState]): (() => Stmt, () => Stmt) =
+    (
+      () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessState),
+      () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessState)
+    )
 }
+
+case class DefinednessState(setDefState: () => Unit)

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -26,16 +26,20 @@ trait DefinednessComponent extends Component {
     * the well-definedness checks for `e`'s subnodes.
     * If `makeChecks` is set to false, then no definedness checks should be emitted. See [[partialCheckDefinedness]]
     * for the purpose of `makeChecks`.
+    * The currently active state represents the state in which expressions should be evaluated.
+    * If `definednessStateOpt` is defined, then it represents the state in which definedness checks
+    * should be made (i.e., where permissions should be checked) and otherwise the definedness state is given by the
+    * currently active state.
    */
   def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                                          definednessState: Option[DefinednessState]): Stmt = Statements.EmptyStmt
+                                          definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
     * Same as [[simplePartialCheckDefinednessBefore]], except that this well-definedness check is invoked and emitted
     * *after* the well-definedness checks of `e`'s subnodes are invoked and emitted.
     */
   def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                                        definednessState: Option[DefinednessState]): Stmt = Statements.EmptyStmt
+                                         definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
    * Proof obligations for a given expression.  The first part of the result is used before
@@ -47,11 +51,16 @@ trait DefinednessComponent extends Component {
    * must be overridden for this parameter to be used.
    */
   def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                             definednessState: Option[DefinednessState]): (() => Stmt, () => Stmt) =
+                              definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) =
     (
-      () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessState),
-      () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessState)
+      () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessStateOpt),
+      () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessStateOpt)
     )
+
 }
 
+/**
+  * Wrapper for representing the definedness state.
+  * @param setDefState Running this should set the currently active state to the definedness state.
+  */
 case class DefinednessState(var setDefState: () => Unit)

--- a/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
@@ -19,13 +19,23 @@ trait ExhaleComponent extends Component {
   /**
    * Exhale a single expression.
    */
-  def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): Stmt = Statements.EmptyStmt
+  def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
+    */
+
+  /***
     * The first part of the result is used before exhaling the expression, and finally after exhaling the expression
     * the second part of the result is used.
+    * @param e
+    * @param error exhale error
+    * @param definednessStateOpt
+    *  If defined, then this expresses the current definedness state. If defined and if the implementing component is
+    *  responsible for the top-level operator in @{code e}, then the component must ensure that that definedness state is
+    *  updated (and restored) correctly.
+    * @return
     */
-  def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): (() => Stmt, () => Stmt) =
-    (() => exhaleExp(e, error, definednessCheckIncluded), () => Statements.EmptyStmt)
+  def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError, definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) =
+    (() => exhaleExp(e, error, definednessStateOpt), () => Statements.EmptyStmt)
 
 }

--- a/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
@@ -19,13 +19,13 @@ trait ExhaleComponent extends Component {
   /**
    * Exhale a single expression.
    */
-  def exhaleExp(e: sil.Exp, error: PartialVerificationError): Stmt = Statements.EmptyStmt
+  def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): Stmt = Statements.EmptyStmt
 
   /**
     * The first part of the result is used before exhaling the expression, and finally after exhaling the expression
     * the second part of the result is used.
     */
-  def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError): (() => Stmt, () => Stmt) =
-    (() => exhaleExp(e, error), () => Statements.EmptyStmt)
+  def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): (() => Stmt, () => Stmt) =
+    (() => exhaleExp(e, error, definednessCheckIncluded), () => Statements.EmptyStmt)
 
 }

--- a/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
@@ -30,10 +30,10 @@ trait ExhaleComponent extends Component {
     * the second part of the result is used.
     * @param e expression to be exhaled.
     * @param error exhale error
-    * @param definednessStateOpt
-    *  If defined, then this expresses the current state in which definedness checks are performed ("definedness state").
-    *  If defined and if the implementing component is responsible for the top-level operator in @{code e}, then the
-    *  component must ensure that that the definedness state is updated (and restored) correctly.
+    * @param definednessStateOpt If defined, then this expresses the current state in which definedness checks are performed
+    *                            ("definedness state"). If defined and if the implementing component is responsible for the
+    *                            top-level operator in @{code e}, then the component must ensure that that the definedness
+    *                            state is updated (and restored) correctly.
     * @return
     */
   def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError, definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) =

--- a/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
@@ -25,14 +25,15 @@ trait ExhaleComponent extends Component {
     */
 
   /***
+    * Method that allows components to contribute to exhaling an expression.
     * The first part of the result is used before exhaling the expression, and finally after exhaling the expression
     * the second part of the result is used.
-    * @param e
+    * @param e expression to be exhaled.
     * @param error exhale error
     * @param definednessStateOpt
-    *  If defined, then this expresses the current definedness state. If defined and if the implementing component is
-    *  responsible for the top-level operator in @{code e}, then the component must ensure that that definedness state is
-    *  updated (and restored) correctly.
+    *  If defined, then this expresses the current state in which definedness checks are performed ("definedness state").
+    *  If defined and if the implementing component is responsible for the top-level operator in @{code e}, then the
+    *  component must ensure that that the definedness state is updated (and restored) correctly.
     * @return
     */
   def exhaleExpBeforeAfter(e: sil.Exp, error: PartialVerificationError, definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) =

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -189,7 +189,7 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
           }
         ))
       }
-      case sil.Unfolding(_, body) =>
+      case sil.Unfolding(_, body) if !insidePackageStmt =>
         val defCheck = maybeDefCheck(e, definednessCheckData)
 
         val checks = components map (_.exhaleExpBeforeAfter(e, error, definednessCheckData.definednessCheckIncluded))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -202,6 +202,7 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
         /** We handle unfolding separately here so that exhale components have the option to gain more information by
           * executing the unfolding (and potentially other unfoldings inside the unfolding body) */
 
+        // We do the definedness check separately.
         val defCheck = maybeDefCheck(e, definednessCheckData)
 
         val definednessCheckDataRec =

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -292,6 +292,7 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
   */
 case class DefinednessCheckData(performDefinednessChecks: Option[PartialVerificationError], definednessStateOpt: Option[DefinednessState])
 {
+
   def copyWhereNoChecksPerformed : DefinednessCheckData  = this.copy(performDefinednessChecks = None)
 
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -258,9 +258,9 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
             exhale components doing the same work as the definedness components do */
           val definednessCheckDataRec =
             if(definednessCheckData.performDefinednessChecks.isDefined) {
-              definednessCheckData.definednessStateOpt
-            } else {
               None
+            } else {
+              definednessCheckData.definednessStateOpt
             }
 
           defCheck ++ invokeExhaleOnComponents(e, error, definednessCheckDataRec)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -244,3 +244,5 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
     }
   }
 }
+
+case class DefinednessCheckData(definednessError: PartialVerificationError, definednessState: Option[DefinednessState])

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -76,13 +76,16 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
 
     nestedExhaleId -= 1
 
+    //only emit initialization of the well-definedness state if the exhale is non-empty
+    val wellDefStateInitStmtOpt : Stmt = if(exhaleStmt.flatten.isEmpty) { Nil } else { wellDefStateInitStmt }
+
     if ((exps map (_._1.isPure) forall identity) || !havocHeap || isAssert) {
       // if all expressions are pure, then there is no need for heap copies
       // if this is a translation of an Assert statement, there is also no need for heap copies
-      wellDefStateInitStmt ++ initStmtWand ++ exhaleStmt ++ assumptions
+      wellDefStateInitStmtOpt ++ initStmtWand ++ exhaleStmt ++ assumptions
     } else {
       beginExhale ++
-      wellDefStateInitStmt ++
+      wellDefStateInitStmtOpt ++
       initStmtWand ++
         exhaleStmt ++
         assumptions ++

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -356,7 +356,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
       }
 
     val stmt =
-      MaybeCommentBlock(definednessDesription, checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessState))
+      MaybeCommentBlock(definednessDescription, checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessState))
 
     if(duringPackageStmt) {
       stateModule.replaceState(oldCurState)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -348,8 +348,15 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
       stateModule.replaceState(wandModule.UNIONState.asInstanceOf[StateRep].state)
     }
 
+    val definednessDesription =
+      if(makeChecks) {
+        s"Check definedness of $e"
+      } else {
+        s"Execute definedness check of $e without enforcing the checks (e.g., to gain more information)"
+      }
+
     val stmt =
-      MaybeCommentBlock(s"Check definedness of $e", checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessState))
+      MaybeCommentBlock(definednessDesription, checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessState))
 
     if(duringPackageStmt) {
       stateModule.replaceState(oldCurState)
@@ -434,7 +441,9 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
             val filter: Exp = hasDirectPerm(eAsForallRef.resource.asInstanceOf[LocationAccess])
 
             handleQuantifiedLocals(bound_vars, If(filter, translate(eAsForallRef, definednessState), Nil))
-          } else handleQuantifiedLocals(bound_vars, translate(Expressions.renameVariables(e, orig_vars.map(_.localVar), bound_vars.map(_.localVar)), definednessState))
+          } else {
+            handleQuantifiedLocals(bound_vars, translate(Expressions.renameVariables(e, orig_vars.map(_.localVar), bound_vars.map(_.localVar)), definednessState))
+          }
           bound_vars map (v => env.undefine(v.localVar))
           res
         } else e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -547,7 +547,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
           }//      case fa@sil.Forall(vars, triggers, expr) => // NOTE: there's no need for a special case for QPs, since these are desugared, introducing conjunctions
       case _ =>
         checkDefinedness(e, definednessError) ++
-          exhale(Seq((e, exhaleError)))
+          exhale(Seq((e, exhaleError, None)))
     }
 
     if(duringPackageStmt) {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -337,7 +337,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
   }
 
   override def checkDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                                definednessState: Option[DefinednessState] = None,
+                                definednessStateOpt: Option[DefinednessState] = None,
                                 duringPackageStmt: Boolean = false, ignoreIfInWand: Boolean = false): Stmt = {
 
     if(duringPackageStmt && ignoreIfInWand)  // ignore the check
@@ -356,7 +356,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
       }
 
     val stmt =
-      MaybeCommentBlock(definednessDescription, checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessState))
+      MaybeCommentBlock(definednessDescription, checkDefinednessImpl(e, error, makeChecks = makeChecks, definednessStateOpt))
 
     if(duringPackageStmt) {
       stateModule.replaceState(oldCurState)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -644,12 +644,15 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         })
       }
       else {
-        f.posts map (e => {
-          exhaleSingleWithDefinedness(
-            whenExhaling(e),
-            errors.PostconditionViolated(e, f),
-            errors.ContractNotWellformed(e))
-        })
+          exhale(
+            f.posts map (e => {
+              (
+                whenExhaling(e),
+                errors.PostconditionViolated(e, f),
+                Some(errors.ContractNotWellformed(e))
+              )
+            })
+          )
       }
       val inhaleCheck = MaybeCommentBlock(
         "Do welldefinedness check of the inhale part.",
@@ -676,12 +679,16 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         MaybeCommentBlock("Checking definedness of postcondition (no body)", posts)
       }
       else {
-        val posts: Seq[Stmt] = f.posts map (e => {
-          exhaleSingleWithDefinedness(
-            e,
-            errors.PostconditionViolated(e, f),
-            errors.ContractNotWellformed(e))
-        })
+        val posts: Seq[Stmt] =
+            exhale(
+              f.posts map (e => {
+                (
+                  e,
+                  errors.PostconditionViolated(e, f),
+                  Some(errors.ContractNotWellformed(e))
+                )
+              })
+            )
         MaybeCommentBlock("Exhaling postcondition (with checking)", posts)
       }
     }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -15,7 +15,7 @@ import viper.silver.{ast => sil}
 import viper.carbon.verifier.{Environment, Verifier}
 import viper.carbon.boogie.Implicits._
 import viper.silver.ast.utility._
-import viper.carbon.modules.components.{DefinednessComponent, ExhaleComponent, InhaleComponent}
+import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, ExhaleComponent, InhaleComponent}
 import viper.silver.verifier.{NullPartialVerificationError, PartialVerificationError, errors}
 
 import scala.collection.mutable.ListBuffer
@@ -722,7 +722,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   override def translateResult(r: sil.Result) = translateResultDecl(r).l
 
   private var tmpStateId = -1
-  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): (() => Stmt, () => Stmt) = {
+  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): (() => Stmt, () => Stmt) = {
     e match {
       case u@sil.Unfolding(acc@sil.PredicateAccessPredicate(loc, perm), exp) =>
         tmpStateId += 1
@@ -752,7 +752,11 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           })} else () => Nil
         )
       }
-      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
+      case _ =>
+        (
+          () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessState),
+          () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessState)
+        )
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -989,7 +989,8 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           /* Execute the unfolding, since we need to update the definedness state (as specified by the interface) and
            * since this may gain information.
            *
-           * Note that executing the unfolding in current evaluation state instead is not safe in general:
+           * Note that executing the unfolding in the current evaluation state (instead of in the definedness state)
+           * instead is not safe in general:
            * In the current evaluation state, the to-be-unfolded predicate may (or may not) have already been exhaled so
            * it is not clear how to execute the unfolding. In a previous version, the unfolding operation was executed
            * in the current evaluation state by inhaling permission to the predicate's body without removing any permission
@@ -1000,8 +1001,13 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           duringUnfoldingExtraUnfold = true
           tmpStateId += 1
           val tmpStateName = if (tmpStateId == 0) "Unfolding" else s"Unfolding$tmpStateId"
-          //Note: the following statement has a side-effect on the definedness state, which is then reverted via @{code restoreState}
-          val (unfoldStmt : Stmt, restoreState) = unfoldingIntoDefinednessState(acc, NullPartialVerificationError, definednessStateOpt.get, tmpStateName)
+          /** Note: the following statement has a side-effect on the definedness state, which is then reverted via @{code restoreState}
+            * Also note that there should always be sufficient permission to the unfolded predicate because there must have been
+            * a definedness check that asserts it before (in the same state).
+            * Nevertheless, we do the check again here to make sure there is no mismatch with the definedness check
+            * (to omit the check, we could pass in a [[NullPartialVerificationError]]).
+            */
+          val (unfoldStmt : Stmt, restoreState) = unfoldingIntoDefinednessState(acc, error, definednessStateOpt.get, tmpStateName)
           duringUnfoldingExtraUnfold = false
 
           def before() : Stmt = {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -772,6 +772,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         val (unfoldStmt : Stmt, restoreState) =
           definednessStateOpt match {
             case Some(defState) =>
+              //Note: the following statement has a side-effect on the definedness state, which is then reverted via @{code restoreState}
               unfoldingIntoDefinednessState(acc, error, defState, tmpStateName)
             case None =>
               val (initStmt, prevState) = stateModule.freshTempState(tmpStateName)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -747,6 +747,13 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
     //unfold into this new state
     val unfoldStmt = unfoldPredicate(predAcc, error, true)
 
+    /** FIXME:
+      * Here we are doing the entire predicate unfolding in the definedness state. That means also all expressions that
+      * are part of the unfolding (e.g., predicate arguments) are evaluated in the definedness state instead of the
+      * evaluation state (i.e., the currently active state before the call). This can lead to discrepancies if the expressions
+      * contain permission introspection.
+      */
+
     //set new definedness state
     defState.setDefState = () => stateModule.replaceState(defStateAfterUnfolding)
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -645,7 +645,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
       }
       else {
         f.posts map (e => {
-          checkDefinednessOfSpecAndExhale(
+          exhaleSingleWithDefinedness(
             whenExhaling(e),
             errors.ContractNotWellformed(e),
             errors.PostconditionViolated(e, f))
@@ -677,7 +677,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
       }
       else {
         val posts: Seq[Stmt] = f.posts map (e => {
-          checkDefinednessOfSpecAndExhale(
+          exhaleSingleWithDefinedness(
             e,
             errors.ContractNotWellformed(e),
             errors.PostconditionViolated(e, f))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -647,8 +647,8 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         f.posts map (e => {
           exhaleSingleWithDefinedness(
             whenExhaling(e),
-            errors.ContractNotWellformed(e),
-            errors.PostconditionViolated(e, f))
+            errors.PostconditionViolated(e, f),
+            errors.ContractNotWellformed(e))
         })
       }
       val inhaleCheck = MaybeCommentBlock(
@@ -679,8 +679,8 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         val posts: Seq[Stmt] = f.posts map (e => {
           exhaleSingleWithDefinedness(
             e,
-            errors.ContractNotWellformed(e),
-            errors.PostconditionViolated(e, f))
+            errors.PostconditionViolated(e, f),
+            errors.ContractNotWellformed(e))
         })
         MaybeCommentBlock("Exhaling postcondition (with checking)", posts)
       }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -444,7 +444,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
             checkDefinedness(w.cond, errors.WhileFailed(w.cond)) ++
             Assume(guard) ++ stateModule.assumeGoodState ++
             MaybeCommentBlock("Translate loop body", stmtModule.translateStmt(w.body)) ++
-            MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
+            MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhaleWithoutDefinedness(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
             MaybeComment("Terminate execution", Assume(FalseLit()))
           stateModule.replaceState(prevState)
           stmts
@@ -550,7 +550,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
         (invs map (inv => inhaleWithDefinednessCheck(inv, errors.ContractNotWellformed(inv)))) ++
           Assume(FalseLit())
       )) ++
-      MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
+      MaybeComment("Exhale invariant", executeUnfoldings(invs, (inv => errors.LoopInvariantNotPreserved(inv))) ++ exhaleWithoutDefinedness(invs map (e => (e, errors.LoopInvariantNotPreserved(e))))) ++
         MaybeComment("Terminate execution", Assume(FalseLit()))
     )
   }
@@ -558,7 +558,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
   private def beforeLoopHead(invs: Seq[sil.Exp], loopIdOpt: Option[Int]): Stmt = {
     MaybeCommentBlock("Before loop head" + loopIdOpt.fold("")(i => Integer.toString(i)),
       MaybeCommentBlock("Exhale loop invariant before loop",
-        executeUnfoldings(invs, (inv => errors.LoopInvariantNotEstablished(inv))) ++ exhale(invs map (e => (e, errors.LoopInvariantNotEstablished(e))))
+        executeUnfoldings(invs, (inv => errors.LoopInvariantNotEstablished(inv))) ++ exhaleWithoutDefinedness(invs map (e => (e, errors.LoopInvariantNotEstablished(e))))
       ) ++
         loopIdOpt.fold(Nil:Stmt)(loopId => {
           val (frameMask, frameHeap) = getFrame(loopId)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -144,7 +144,7 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
             }
             else Nil
             val postsWithErrors = posts map (p => (p, errors.PostconditionViolated(p, mWithLoopInfo)))
-            val exhalePost = MaybeCommentBlock("Exhaling postcondition", exhale(postsWithErrors))
+            val exhalePost = MaybeCommentBlock("Exhaling postcondition", exhaleWithoutDefinedness(postsWithErrors))
             val body: Stmt = translateStmt(method.bodyOrAssumeFalse)
               /* TODO: Might be worth special-casing on methods with empty bodies */
             val proc = Procedure(Identifier(name), ins, outs,

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
@@ -8,7 +8,7 @@ package viper.carbon.modules.impls
 
 import viper.carbon.boogie._
 import viper.carbon.modules.MapModule
-import viper.carbon.modules.components.DefinednessComponent
+import viper.carbon.modules.components.{DefinednessComponent, DefinednessState}
 import viper.carbon.modules.impls.map_axioms.MapAxiomatization
 import viper.carbon.verifier.Verifier
 import viper.silver.verifier.{PartialVerificationError, reasons}
@@ -83,7 +83,7 @@ class DefaultMapModule(val verifier: Verifier) extends MapModule with Definednes
     NamedType("Map", Seq(translateType(mapType.keyType), translateType(mapType.valueType)))
   }
 
-  override def simplePartialCheckDefinednessAfter(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
     if (makeChecks) exp match {
       case sil.MapLookup(base, key) => {
         val containsExp = translateMapExp(sil.MapContains(key, base)(exp.pos, exp.info, exp.errT))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
@@ -83,7 +83,7 @@ class DefaultMapModule(val verifier: Verifier) extends MapModule with Definednes
     NamedType("Map", Seq(translateType(mapType.keyType), translateType(mapType.valueType)))
   }
 
-  override def simplePartialCheckDefinednessAfter(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
+  override def simplePartialCheckDefinednessAfter(exp: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): Stmt = {
     if (makeChecks) exp match {
       case sil.MapLookup(base, key) => {
         val containsExp = translateMapExp(sil.MapContains(key, base)(exp.pos, exp.info, exp.errT))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
@@ -12,7 +12,7 @@ import viper.carbon.boogie._
 import viper.carbon.verifier.Verifier
 import viper.carbon.boogie.Implicits._
 import viper.carbon.modules.impls.dafny_axioms.SequenceAxiomatization
-import viper.carbon.modules.components.DefinednessComponent
+import viper.carbon.modules.components.{DefinednessComponent, DefinednessState}
 import viper.silver.ast.{SeqIndex, SeqLength}
 import viper.silver.verifier.{PartialVerificationError, reasons}
 
@@ -110,7 +110,7 @@ class DefaultSeqModule(val verifier: Verifier)
   }
 
 
-  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
 
     if(makeChecks)
       e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
@@ -110,7 +110,7 @@ class DefaultSeqModule(val verifier: Verifier)
   }
 
 
-  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): Stmt = {
 
     if(makeChecks)
       e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -6,7 +6,7 @@
 
 package viper.carbon.modules.impls
 
-import viper.carbon.modules.{DefinednessCheckData, StatelessComponent, StmtModule}
+import viper.carbon.modules.{StatelessComponent, StmtModule}
 import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, SimpleStmtComponent}
 import viper.silver.ast.utility.Expressions.{whenExhaling, whenInhaling}
 import viper.silver.{ast => sil}

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -290,7 +290,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
   }
 
 
-  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
+  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): Stmt = {
     if(makeChecks) {
       e match {
         case labelOld@sil.LabelledOld(_, labelName) =>

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -7,7 +7,7 @@
 package viper.carbon.modules.impls
 
 import viper.carbon.modules.{StatelessComponent, StmtModule}
-import viper.carbon.modules.components.{DefinednessComponent, SimpleStmtComponent}
+import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, SimpleStmtComponent}
 import viper.silver.ast.utility.Expressions.{whenExhaling, whenInhaling}
 import viper.silver.{ast => sil}
 import viper.carbon.boogie._
@@ -282,7 +282,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
   }
 
 
-  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
     if(makeChecks) {
       e match {
         case labelOld@sil.LabelledOld(_, labelName) =>

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -134,7 +134,6 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case exh@sil.Exhale(e) =>
         val transformedExp = whenExhaling(e)
         val defErrorOpt = maybeDefError(errors.ExhaleFailed(exh))
-        //checkDefinedness(transformedExp, errors.ExhaleFailed(exh), insidePackageStmt = insidePackageStmt, ignoreIfInWand = true)++
         exhale(Seq((transformedExp, errors.ExhaleFailed(exh), defErrorOpt)), statesStackForPackageStmt = statesStack, insidePackageStmt = insidePackageStmt)
       case a@sil.Assert(e) =>
         val transformedExp = whenExhaling(e)
@@ -142,7 +141,6 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
 
         if (transformedExp.isPure) {
           // if e is pure, then assert and exhale are the same
-          //checkDefinedness(transformedExp, errors.AssertFailed(a), insidePackageStmt = insidePackageStmt, ignoreIfInWand = true) ++
           exhale(Seq((transformedExp, errors.AssertFailed(a), defErrorOpt)), statesStackForPackageStmt = statesStack, insidePackageStmt = insidePackageStmt)
         } else {
           // we create a temporary state to ignore the side-effects

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -688,9 +688,9 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
     val defineLHS = stmtModule.translateStmt(sil.Label("lhs"+lhsID, Nil)(w.pos, w.info))
     wandModule.pushToActiveWandsStack(lhsID)
 
-    val ret = CommentBlock("check if wand is held and remove an instance",exhaleModule.exhale((w, error), false, insidePackageStmt = inWand, statesStackForPackageStmt = statesStack)) ++
+    val ret = CommentBlock("check if wand is held and remove an instance",exhaleModule.exhaleSingleWithoutDefinedness(w, error, false, insidePackageStmt = inWand, statesStackForPackageStmt = statesStack)) ++
       (if(inWand) exchangeAssumesWithBoolean(stateModule.assumeGoodState, OPS.boolVar) else stateModule.assumeGoodState) ++
-      CommentBlock("check if LHS holds and remove permissions ", exhaleModule.exhale((w.left, error), false, insidePackageStmt = inWand, statesStackForPackageStmt = statesStack)) ++
+      CommentBlock("check if LHS holds and remove permissions ", exhaleModule.exhaleSingleWithoutDefinedness(w.left, error, false, insidePackageStmt = inWand, statesStackForPackageStmt = statesStack)) ++
       (if(inWand) exchangeAssumesWithBoolean(stateModule.assumeGoodState, OPS.boolVar) else stateModule.assumeGoodState) ++
       CommentBlock("inhale the RHS of the wand",inhaleModule.inhale(Seq((w.right, error)), addDefinednessChecks = false, statesStackForPackageStmt = statesStack, insidePackageStmt = inWand)) ++
       heapModule.beginExhale ++ heapModule.endExhale ++

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -11,7 +11,7 @@ import viper.carbon.modules._
 import viper.carbon.verifier.Verifier
 import viper.carbon.boogie._
 import viper.carbon.boogie.Implicits._
-import viper.carbon.modules.components.{DefinednessComponent, StmtComponent}
+import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, StmtComponent}
 import viper.silver.ast.utility.Expressions
 import viper.silver.ast.{MagicWand, MagicWandStructure}
 import viper.silver.verifier.{PartialVerificationError, reasons}
@@ -730,7 +730,7 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
   /**
     * Checking definedness for applying statement
     */
-  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): (() => Stmt, () => Stmt) = {
+  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): (() => Stmt, () => Stmt) = {
     e match {
       case a@sil.Applying(wand, exp) =>
         tmpStateId += 1
@@ -745,7 +745,11 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
           Nil
         }
         (before _, after _)
-      case _ => (() => simplePartialCheckDefinednessBefore(e, error, makeChecks), () => simplePartialCheckDefinednessAfter(e, error, makeChecks))
+      case _ =>
+        (
+          () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessState),
+          () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessState)
+        )
     }
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -730,7 +730,7 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
   /**
     * Checking definedness for applying statement
     */
-  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): (() => Stmt, () => Stmt) = {
+  override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) = {
     e match {
       case a@sil.Applying(wand, exp) =>
         tmpStateId += 1
@@ -747,8 +747,8 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
         (before _, after _)
       case _ =>
         (
-          () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessState),
-          () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessState)
+          () => simplePartialCheckDefinednessBefore(e, error, makeChecks, definednessStateOpt),
+          () => simplePartialCheckDefinednessAfter(e, error, makeChecks, definednessStateOpt)
         )
     }
   }

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -353,7 +353,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     }
   }
 
-  override def exhaleExp(e: sil.Exp, error: PartialVerificationError): Stmt = {
+  override def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): Stmt = {
     e match {
       case sil.AccessPredicate(loc: LocationAccess, prm) =>
         val curPerm = currentPermission(loc)

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -353,7 +353,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     }
   }
 
-  override def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessCheckIncluded: (Boolean, DefinednessState)): Stmt = {
+  override def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessCheckOpt: Option[DefinednessState]): Stmt = {
     e match {
       case sil.AccessPredicate(loc: LocationAccess, prm) =>
         val curPerm = currentPermission(loc)

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -373,8 +373,8 @@ class QuantifiedPermModule(val verifier: Verifier)
         if (!p.isInstanceOf[sil.WildcardPerm]) {
           val prmTranslated = translatePerm(p)
 
-          Assert(permissionPositiveInternal(prmTranslated, Some(p), true), error.dueTo(reasons.NegativePermission(p))) ++
             (permVar := prmTranslated) ++
+              Assert(permissionPositiveInternal(permVar, Some(p), true), error.dueTo(reasons.NegativePermission(p))) ++
             If(permVar !== noPerm,
               Assert(permLe(permVar, curPerm), error.dueTo(reasons.InsufficientPermission(loc))),
               Nil) ++

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -298,36 +298,34 @@ class QuantifiedPermModule(val verifier: Verifier)
   private def hasDirectPerm(obj: Exp, loc: Exp): Exp = hasDirectPerm(maskExp, obj, loc)
 
   override def hasDirectPerm(la: sil.LocationAccess): Exp = {
-    hasDirectPerm(la, translateLocation(la))
+    hasDirectPerm(translateReceiver(la), translateLocation(la))
   }
 
-
   /**
-    * Returns Boolean expression checking whether there is nonzero to the input location in the provided permission state
-    * @param la
-    * @param setToPermState permission state
+    * Returns Boolean expression checking whether there is nonzero permission to the input location in the provided permission state.
+    * The input location itself is translated in the original state (not in the provided permission state)
+    * @param la input location
+    * @param setToPermState permission state in which the permission is checked
     * @return
     */
   private def hasDirectPerm(la: sil.LocationAccess, setToPermState: () => Unit): Exp = {
+    val translatedRcv = translateReceiver(la)
     val translatedLoc = translateLocation(la)
 
     val state = stateModule.state
     setToPermState()
-    val res = hasDirectPerm(la, translatedLoc)
+    val res = hasDirectPerm(translatedRcv, translatedLoc)
     stateModule.replaceState(state)
 
     res
   }
 
-  private def hasDirectPerm(la: sil.LocationAccess, translatedLocation: Exp): Exp = {
+  private def translateReceiver(la: sil.LocationAccess) : Exp  = {
     la match {
-      case sil.FieldAccess(rcv, _) =>
-        hasDirectPerm(translateExp(rcv), translatedLocation)
-      case sil.PredicateAccess(_, _) =>
-        hasDirectPerm(translateNull, translatedLocation)
+      case sil.FieldAccess(rcv, _) => translateExp(rcv)
+      case sil.PredicateAccess(_, _) => translateNull
     }
   }
-
 
   /**
    * Expression that expresses that 'permission' is positive. 'silPerm' is used to

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -1544,12 +1544,12 @@ class QuantifiedPermModule(val verifier: Verifier)
     permLe(b, a, forField)
   }
 
-  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): Stmt = {
 
     val stmt: Stmt = if(makeChecks) (
       e match {
         case fa@sil.LocationAccess(_) =>
-          val hasDirectPermExp = definednessState.fold(hasDirectPerm(fa))(defState => hasDirectPerm(fa, defState.setDefState))
+          val hasDirectPermExp = definednessStateOpt.fold(hasDirectPerm(fa))(defState => hasDirectPerm(fa, defState.setDefState))
           Assert(hasDirectPermExp, error.dueTo(reasons.InsufficientPermission(fa)))
         case sil.PermDiv(a, b) =>
           Assert(translateExp(b) !== IntLit(0), error.dueTo(reasons.DivisionByZero(b)))

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -1526,7 +1526,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     permLe(b, a, forField)
   }
 
-  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  override def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessState: Option[DefinednessState]): Stmt = {
 
     val stmt: Stmt = if(makeChecks) (
       e match {

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -301,6 +301,13 @@ class QuantifiedPermModule(val verifier: Verifier)
     hasDirectPerm(la, translateLocation(la))
   }
 
+
+  /**
+    * Returns Boolean expression checking whether there is nonzero to the input location in the provided permission state
+    * @param la
+    * @param setToPermState permission state
+    * @return
+    */
   private def hasDirectPerm(la: sil.LocationAccess, setToPermState: () => Unit): Exp = {
     val translatedLoc = translateLocation(la)
 


### PR DESCRIPTION
Previously, the encoding for `exhale A` first checked well-definedness of `A` and in a second step performed the actual exhale. This approach is flawed, because (1) well-definedness of `A` depends on the actual exhale in the general case and (2) in cases where the exhale fails, the reported errors are not the expected ones. See https://github.com/viperproject/carbon/issues/406 for examples illustrating these two problems.

This PR implements an exhale implementation, which (if enabled) does the well-definedness checks during the exhale (as we already do with inhale).

