### PR TITLE
Allow calls of non-domain functions without preconditions from domain axioms

### DIFF
--- a/src/main/scala/viper/carbon/modules/StateModule.scala
+++ b/src/main/scala/viper/carbon/modules/StateModule.scala
@@ -119,6 +119,12 @@ trait StateModule extends Module with ComponentRegistry[CarbonStateComponent] wi
    */
   def oldState: StateSnapshot
 
+
+  /**
+    * Get a pure state without a heap.
+    */
+  def pureState: StateSnapshot
+
   /**
    * Replace the old state with a given snapshot.
    */
@@ -143,6 +149,11 @@ trait StateModule extends Module with ComponentRegistry[CarbonStateComponent] wi
    * Are we currently using an 'old' state? Implies that we should wrap relevant state components in "Old"
    */
   def stateModuleIsUsingOldState: Boolean
+
+  /**
+    * Are we currently using a pure state with no heap?
+    */
+  def stateModuleIsUsingPureState: Boolean
 
   /**
    * * Store a StateSnapshot in a retrievable map, with the given name as key

--- a/src/main/scala/viper/carbon/modules/StateModule.scala
+++ b/src/main/scala/viper/carbon/modules/StateModule.scala
@@ -59,13 +59,18 @@ trait StateModule extends Module with ComponentRegistry[CarbonStateComponent] wi
    * same even if the state is changed.
    */
   def staticStateContributions(withHeap : Boolean = true, withPermissions : Boolean = true): Seq[LocalVarDecl]
+
   /**
    * The current values for all registered components' state contributions.  The number of elements
    * in the list and the types must correspond to the ones given in `stateContributions`.
     *
     * Compared to the currentStateContributions [ALEX: maybe to be deprecated], these expressions may include e.g. old(..) around a heap variable.
    */
-  def currentStateContributionValues: Seq[Exp] = stateContributionValues(state)
+  def currentStateContributionValues: Seq[Exp] = {
+    // TODO: This implementation does not return the values of the old or pure state if we're currently using one of those;
+    // instead it only wraps expressions into old(..) if we're using the old state.
+    stateContributionValues(state)
+  }
 
   def stateContributionValues(snap : StateSnapshot): Seq[Exp]
 

--- a/src/main/scala/viper/carbon/modules/components/CarbonStateComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/CarbonStateComponent.scala
@@ -70,4 +70,9 @@ trait CarbonStateComponent extends Component {
    * Note in particular that variable passed in via "replaceState" above will typically need wrapping in old(.) if this is set to true
    */
   def usingOldState: Boolean
+
+  /**
+    * Are we currently using a pure state without a heap (i.e., translating a domain)?
+    */
+  def usingPureState: Boolean
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
@@ -31,10 +31,13 @@ class DefaultDomainModule(val verifier: Verifier) extends DomainModule with Stat
   def outputName(domain: sil.Domain) : String = domain.name + "DomainType"
 
   override def translateDomain(domain: sil.Domain): Seq[Decl] = {
+    val prevState = stateModule.state
+    stateModule.replaceState(stateModule.pureState)
     val fs = domain.functions.filter(f => f.interpretation.isEmpty) flatMap translateDomainFunction
     val as = domain.axioms flatMap translateDomainAxiom
     val ts = CommentedDecl(s"The type for domain ${domain.name}",
       TypeDecl(NamedType(this.outputName(domain) , domain.typVars map (tv => TypeVar(tv.name)))), size = 1)
+    stateModule.replaceState(prevState)
     CommentedDecl(s"Translation of domain ${domain.name}", ts ++ fs ++ as, nLines = 2)
   }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -82,7 +82,7 @@ class DefaultHeapModule(val verifier: Verifier)
   private val qpHeap = LocalVar(qpHeapName, heapTyp)
   private var heap: Var = originalHeap
   private def heapVar: Var = {assert (!usingOldState); heap}
-  private def heapExp: Exp = (if (usingOldState) Old(heap) else heap)
+  private def heapExp: Exp = if (usingPureState) dummyHeap else (if (usingOldState) Old(heap) else heap)
   private val nullName = Identifier("null")
   private val nullLit = Const(nullName)
   private val freshObjectName = Identifier("freshObj")
@@ -100,6 +100,8 @@ class DefaultHeapModule(val verifier: Verifier)
   private val sumHeapName = Identifier("SumHeap")
   private val readHeapName = Identifier("readHeap")
   private val updateHeapName = Identifier("updHeap")
+  private val dummyHeapName = Identifier("dummyHeap")
+  private val dummyHeap = Const(dummyHeapName)
 
   override def refType = NamedType("Ref")
 
@@ -121,6 +123,7 @@ class DefaultHeapModule(val verifier: Verifier)
       ConstDecl(nullName, refType) ++
       TypeDecl(fieldType) ++
       TypeDecl(normalFieldType) ++
+      ConstDecl(dummyHeapName, heapTyp) ++
       // Heap Type Definition :
       (if(verifier.usePolyMapsInEncoding) TypeAlias(heapTyp, MapType(Seq(refType, fieldType), TypeVar("B"), Seq(TypeVar("A"), TypeVar("B")))) else TypeDecl(heapTyp)) ++
       (if(enableAllocationEncoding) ConstDecl(allocName, NamedType(fieldTypeName, Seq(normalFieldType, Bool)), unique = true) ++
@@ -796,6 +799,7 @@ class DefaultHeapModule(val verifier: Verifier)
 
   override def usingOldState = stateModuleIsUsingOldState
 
+  override def usingPureState = stateModuleIsUsingPureState
 
   override def beginExhale: Stmt = {
 //    Havoc(exhaleHeap)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -31,8 +31,17 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
     Assume(currentGoodState)
   }
 
-  override def preamble = {
-    Func(Identifier(isGoodState), staticStateContributions(), Bool)
+  override def preamble: Seq[Decl] = {
+    Func(Identifier(isGoodState), staticStateContributions(), Bool) ++
+    {
+      val prevState = stateModule.state
+      stateModule.replaceState(stateModule.pureState)
+      val stateExps = components flatMap (_.currentStateExps)
+      val res = FuncApp(Identifier(isGoodState), stateExps, Bool)
+      stateModule.replaceState(prevState)
+      // state(dummyHeap, emptyMask)
+      Axiom(res)
+    }
   }
 
   override def reset : Unit = {
@@ -97,7 +106,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
   // Note: For "old" state, these variables should be wrapped in "Old(.)" before use
   type StateComponentMapping = java.util.IdentityHashMap[CarbonStateComponent, Seq[Var]]
-  override type StateSnapshot = (StateComponentMapping, Boolean, Boolean) // mapping to vars, using old state, treating old state as current
+  override type StateSnapshot = (StateComponentMapping, Boolean, Boolean) // mapping to vars, using old state, using pure state
 
   private var curOldState: StateComponentMapping = null
   private var curState: StateComponentMapping = null
@@ -117,7 +126,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   override def stateRepositoryGet(name:String) : Option[StateSnapshot] = stateRepository.get(name)
 
   override def freshTempState(name: String, discardCurrent: Boolean = false, initialise: Boolean = false): (Stmt, StateSnapshot) = {
-    val previousState = new StateSnapshot(new StateComponentMapping(), usingOldState, false)
+    val previousState = new StateSnapshot(new StateComponentMapping(), usingOldState, usingPureState)
 
     curState = new StateComponentMapping() // essentially, the code below "clones" what curState should represent anyway. But, if we omit this line, we inadvertently alias the previous hash map.
 
@@ -164,6 +173,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
       c.restoreState(snapshot._1.get(c))
     }
     usingOldState = snapshot._2
+    usingPureState = snapshot._3
   }
 
   override def equateHeaps(snapshot: StateSnapshot, c: CarbonStateComponent):Stmt =
@@ -173,13 +183,22 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
   // initialisation in principle not needed - one should call initState
   var usingOldState = false
+  var usingPureState = false
 
   override def stateModuleIsUsingOldState: Boolean = {
     usingOldState
   }
 
+  override def stateModuleIsUsingPureState: Boolean = {
+    usingPureState
+  }
+
   override def oldState: StateSnapshot = {
-    (curOldState,true,false) // the chosen boolean values here seem sensible, but they probably shouldn't be used anyway
+    (curOldState, true, false) // the chosen boolean values here seem sensible, but they probably shouldn't be used anyway
+  }
+
+  override def pureState: StateSnapshot = {
+    (curState, false, true)
   }
 
   override def replaceOldState(snapshot: StateSnapshot): Unit = {
@@ -187,7 +206,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   override def state: StateSnapshot = {
-    (curState,usingOldState,false)
+    (curState, usingOldState, usingPureState)
   }
 
   override def getCopyState:StateSnapshot = {
@@ -195,6 +214,6 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
     val s = for (c <- components) yield {
                 currentCopy.put(c, c.currentStateVars)
             }
-    (currentCopy, usingOldState, false)
+    (currentCopy, usingOldState, usingPureState)
   }
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -36,10 +36,14 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
     {
       val prevState = stateModule.state
       stateModule.replaceState(stateModule.pureState)
+      // TODO: It would be great if we could use StateModule.currentStateContributionValues, but that will not
+      // give us the pure state (see comment there). Once that is fixed, this should be changed accordingly.
       val stateExps = components flatMap (_.currentStateExps)
       val res = FuncApp(Identifier(isGoodState), stateExps, Bool)
       stateModule.replaceState(prevState)
-      // state(dummyHeap, emptyMask)
+      // This axiom corresponds to the Boogie expression "state(dummyHeap, emptyMask)",
+      // which is necessary since function definitional axioms trigger on "state(heap, mask), f(heap, args)",
+      // so without this assumption, function calls with dummyHeap and emptyMask won't trigger the definition.
       Axiom(res)
     }
   }

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -85,7 +85,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   private val originalMask = GlobalVar(maskName, maskType)
   private var mask: Var = originalMask // When reading, don't use this directly: use either maskVar or maskExp as needed
   private def maskVar : Var = {assert (!usingOldState); mask}
-  private def maskExp : Exp = (if (usingOldState) Old(mask) else mask)
+  private def maskExp : Exp = if (usingPureState) zeroMask else (if (usingOldState) Old(mask) else mask)
   private val zeroMaskName = Identifier("ZeroMask")
   private val zeroMask = Const(zeroMaskName)
   private val zeroPMaskName = Identifier("ZeroPMask")
@@ -266,6 +266,8 @@ class QuantifiedPermModule(val verifier: Verifier)
   }
 
   override def usingOldState = stateModuleIsUsingOldState
+
+  override def usingPureState: Boolean = stateModuleIsUsingPureState
 
   override def predicateMaskField(pred: Exp): Exp = {
     FuncApp(predicateMaskFieldName, Seq(pred), pmaskType)


### PR DESCRIPTION
Carbon changes matching Silver PR: https://github.com/viperproject/silver/pull/698

Introduces the notion of a "pure state" in the state module, which uses the empty mask and a dummy heap.
The dummy heap is used as the heap argument when translating calls to non-domain functions without preconditions inside domain axioms (which have a heap argument on the Boogie level but never use it), since the ordinary global ``Heap`` variable cannot be used inside an axiom (only constants can).