### PR TITLE
clean up postcondition framedness check

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -168,9 +168,7 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
   }
 
   private def translateMethodDeclCheckPosts(posts: Seq[sil.Exp]): Stmt = {
-    val (stmt, state) = stateModule.freshTempState("Post")
-
-    val reset = stateModule.resetBoogieState
+    val (freshStateStmt, state) = stateModule.freshTempState("Post", discardCurrent = true, initialise = true)
 
     // note that the order here matters - onlyExhalePosts should be computed with respect to the reset state
     val onlyExhalePosts: Seq[Stmt] = inhaleModule.inhaleExhaleSpecWithDefinednessCheck(
@@ -178,31 +176,33 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
       errors.ContractNotWellformed(_)
     })
 
-    val stmts = stmt ++ reset ++ (
-    if (Expressions.contains[sil.InhaleExhaleExp](posts)) {
-      // Postcondition contains InhaleExhale expression.
-      // Need to check inhale and exhale parts separately.
-      val onlyInhalePosts: Seq[Stmt] = inhaleModule.inhaleInhaleSpecWithDefinednessCheck(
-      posts, {
-        errors.ContractNotWellformed(_)
-      })
+    val stmts = (
+      if (Expressions.contains[sil.InhaleExhaleExp](posts)) {
+        // Postcondition contains InhaleExhale expression.
+        // Need to check inhale and exhale parts separately.
+        val onlyInhalePosts: Seq[Stmt] = inhaleModule.inhaleInhaleSpecWithDefinednessCheck(
+        posts, {
+          errors.ContractNotWellformed(_)
+        })
 
-          NondetIf(
+        NondetIf(
+          freshStateStmt ++
           MaybeComment("Checked inhaling of postcondition to check definedness",
             MaybeCommentBlock("Do welldefinedness check of the inhale part.",
               NondetIf(onlyInhalePosts ++ Assume(FalseLit()))) ++
               MaybeCommentBlock("Normally inhale the exhale part.",
                 onlyExhalePosts)
           ) ++
-            MaybeComment("Stop execution", Assume(FalseLit()))
-      )
-    }
-    else {
-      NondetIf(
-        MaybeComment("Checked inhaling of postcondition to check definedness", onlyExhalePosts) ++
           MaybeComment("Stop execution", Assume(FalseLit()))
-      )
-    })
+        )
+      }
+      else {
+        NondetIf(
+          freshStateStmt ++
+          MaybeComment("Checked inhaling of postcondition to check definedness", onlyExhalePosts) ++
+            MaybeComment("Stop execution", Assume(FalseLit()))
+        )
+      })
 
     stateModule.replaceState(state)
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -168,7 +168,8 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
   }
 
   private def translateMethodDeclCheckPosts(posts: Seq[sil.Exp]): Stmt = {
-    val (freshStateStmt, state) = stateModule.freshTempState("Post", discardCurrent = true, initialise = true)
+    val (freshStateStmtAux, state) = stateModule.freshTempState("Post", discardCurrent = true, initialise = true)
+    val freshStateStmt = freshStateStmtAux ++ stateModule.assumeGoodState
 
     // note that the order here matters - onlyExhalePosts should be computed with respect to the reset state
     val onlyExhalePosts: Seq[Stmt] = inhaleModule.inhaleExhaleSpecWithDefinednessCheck(


### PR DESCRIPTION
The method postcondition is checked to be properly framed in a fresh state as follows:

```
inhale precondition
PostMask := Mask;
PostHeap := Heap;
havoc PostHeap;
PostMask := ZeroMask
 if(*) {
   check postcondition framed in (PostHeap, PostMask)
   assume false;
}
translate main body of method
exhale postcondition
```

The initial assignments to `PostMask` and `PostHeap` are superfluous. Moreover, the post state setup is only relevant inside the then-branch of the non-deterministic if statement. This PR makes this explicit by changing the encoding to:

```
inhale precondition
 if(*) {
   havoc PostHeap;
   PostMask := ZeroMask;
   check postcondition framed in (PostHeap, PostMask)
   assume false;
}
translate main body of method
exhale postcondition
```
