### PR TITLE
Havoc scoped variables explicitly

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -253,9 +253,11 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case sil.Seqn(ss, scopedDecls) =>
         val locals = scopedDecls.collect {case l: sil.LocalVarDecl => l}
         locals map (v => mainModule.env.define(v.localVar)) // add local variables to environment
-        val s =
+        val s = {
+          MaybeCommentBlock("Havoc scoped variables", locals map (lv => Havoc(mainModule.env.get(lv.localVar)))) ++
           MaybeCommentBlock("Assumptions about local variables", locals map (a => mainModule.allAssumptionsAboutValue(a.typ, mainModule.translateLocalVarDecl(a), true))) ++
           Seqn(ss map (st => translateStmt(st, statesStack, allStateAssms, duringPackage)))
+        }
         locals map (v => mainModule.env.undefine(v.localVar)) // remove local variables from environment
         // return to avoid adding a comment, and to avoid the extra 'assumeGoodState'
         return s


### PR DESCRIPTION
This pull request adds explicit havocs to scoped variables. Previously, havocs were omitted, which is sound because Carbon introduces a unique Boogie variable for each scoped variable and thus the implicit havoc for the variable at the beginning of the program is sufficient. The reason for adding explicit havocs is (1) to make the encoding reflect the Viper program structure more closely, and (2) to allow reusing the same Boogie variable for scoped variables that do not overlap.