### PR TITLE
Unfold, fold, and unfolding must have a strictly positive permission amount

### DIFF
--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -45,6 +45,14 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def conservativeIsPositivePerm(e: sil.Exp): Boolean
 
+  /**
+    * Returns an expression representing that a permission amount is positive.
+    * Similar to [[permissionPositive]], but works directly on Viper expressions, *including* ones containing
+    * wildcards, and performs more aggressive simplifications.
+    *
+    * @param e the permission amount to be checked
+    * @return the expression representing the fact that the permission is positive
+    */
   def isStrictlyPositivePerm(e: sil.Exp): Exp
 
   /**

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -45,6 +45,8 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def conservativeIsPositivePerm(e: sil.Exp): Boolean
 
+  def isStrictlyPositivePerm(e: sil.Exp): Exp
+
   /**
    * The current mask.
    */

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -967,14 +967,14 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
     duringUnfold = true
     duringUnfolding = isUnfolding
     unfoldInfo = acc
-    val stmt = Assume(predicateTrigger(heapModule.currentStateExps, acc.loc)) ++
+    val stmt = Assert(permModule.isStrictlyPositivePerm(acc.perm), error.dueTo(NonPositivePermission(acc.perm))) ++
+      Assume(predicateTrigger(heapModule.currentStateExps, acc.loc)) ++
       {
         val location = acc.loc
         val predicate = verifier.program.findPredicate(location.predicateName)
         val translatedArgs = location.args map translateExp
         Assume(translateLocationAccess(location) === getPredicateFrame(predicate,translatedArgs)._1)
       } ++
-      Assert(permModule.isStrictlyPositivePerm(acc.perm), error.dueTo(NonPositivePermission(acc.perm))) ++
       (if(exhaleUnfoldedPredicate)
           exhaleSingleWithoutDefinedness(acc, error, havocHeap = false, statesStackForPackageStmt = statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)
       else Nil) ++ inhale(Seq((Permissions.multiplyExpByPerm(acc.loc.predicateBody(verifier.program, env.allDefinedNames(program)).get,acc.perm), error)), addDefinednessChecks = false, statesStackForPackageStmt = statesStackForPackageStmt, insidePackageStmt = insidePackageStmt)

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -1601,26 +1601,30 @@ class QuantifiedPermModule(val verifier: Verifier)
 
   override def conservativeIsPositivePerm(e: sil.Exp): Boolean = PermissionHelper.conservativeStaticIsStrictlyPositivePerm(e)
 
+  override def isStrictlyPositivePerm(e: sil.Exp): Exp = PermissionHelper.isStrictlyPositivePerm(e)
+
   object PermissionHelper {
 
     def isStrictlyPositivePerm(e: sil.Exp): Exp = {
       require(e isSubtype sil.Perm, s"found ${e.typ} ($e), but required Perm")
-      val backup = permissionPositiveInternal(translatePerm(e), Some(e))
+      // Use backup lazily when needed only. This allows the function to work on WildcardPerms for which
+      // translatePerm would throw an exception.
+      val backup = () => permissionPositiveInternal(translatePerm(e), Some(e))
       e match {
         case sil.NoPerm() => FalseLit()
         case sil.FullPerm() => TrueLit()
         case sil.WildcardPerm() => TrueLit()
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
         case x: sil.LocalVar if isAbstractRead(x) => TrueLit()
-        case sil.CurrentPerm(loc) => backup
+        case sil.CurrentPerm(loc) => backup()
         case sil.FractionalPerm(left, right) =>
           val (l, r) = (translateExp(left), translateExp(right))
           ((l > IntLit(0)) && (r > IntLit(0))) || ((l < IntLit(0)) && (r < IntLit(0)))
         case sil.PermMinus(a) =>
           isStrictlyNegativePerm(a)
         case sil.PermAdd(left, right) =>
-          (isStrictlyPositivePerm(left) && isStrictlyPositivePerm(right)) || backup
-        case sil.PermSub(left, right) => backup
+          (isStrictlyPositivePerm(left) && isStrictlyPositivePerm(right)) || backup()
+        case sil.PermSub(left, right) => backup()
         case sil.PermMul(a, b) =>
           (isStrictlyPositivePerm(a) && isStrictlyPositivePerm(b)) || (isStrictlyNegativePerm(a) && isStrictlyNegativePerm(b))
         case sil.PermDiv(a, b) =>
@@ -1633,7 +1637,7 @@ class QuantifiedPermModule(val verifier: Verifier)
           ((n > IntLit(0)) && isStrictlyPositivePerm(b)) || ((n < IntLit(0)) && isStrictlyNegativePerm(b))
         case sil.CondExp(cond, thn, els) =>
           CondExp(translateExp(cond), isStrictlyPositivePerm(thn), isStrictlyPositivePerm(els))
-        case _ => backup
+        case _ => backup()
       }
     }
 
@@ -1705,22 +1709,24 @@ class QuantifiedPermModule(val verifier: Verifier)
 
     def isStrictlyNegativePerm(e: sil.Exp): Exp = {
       require(e isSubtype sil.Perm)
-      val backup = UnExp(Not,permissionPositiveInternal(translatePerm(e), Some(e), true))
+      // Use backup lazily when needed only. This allows the function to work on WildcardPerms for which
+      // translatePerm would throw an exception.
+      val backup = () => UnExp(Not,permissionPositiveInternal(translatePerm(e), Some(e), true))
       e match {
         case sil.NoPerm() => FalseLit() // strictly negative
         case sil.FullPerm() => FalseLit()
         case sil.WildcardPerm() => FalseLit()
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
         case x: sil.LocalVar if isAbstractRead(x) => FalseLit()
-        case sil.CurrentPerm(loc) => backup
+        case sil.CurrentPerm(loc) => backup()
         case sil.FractionalPerm(left, right) =>
           val (l, r) = (translateExp(left), translateExp(right))
           ((l < IntLit(0)) && (r > IntLit(0))) || ((l > IntLit(0)) && (r < IntLit(0)))
         case sil.PermMinus(a) =>
           isStrictlyPositivePerm(a)
         case sil.PermAdd(left, right) =>
-          (isStrictlyNegativePerm(left) && isStrictlyNegativePerm(right)) || backup
-        case sil.PermSub(left, right) => backup
+          (isStrictlyNegativePerm(left) && isStrictlyNegativePerm(right)) || backup()
+        case sil.PermSub(left, right) => backup()
         case sil.PermMul(a, b) =>
           (isStrictlyPositivePerm(a) && isStrictlyNegativePerm(b)) || (isStrictlyNegativePerm(a) && isStrictlyPositivePerm(b))
         case sil.PermDiv(a, b) =>
@@ -1733,7 +1739,7 @@ class QuantifiedPermModule(val verifier: Verifier)
           ((n > IntLit(0)) && isStrictlyNegativePerm(b)) || ((n < IntLit(0)) && isStrictlyPositivePerm(b))
         case sil.CondExp(cond, thn, els) =>
           CondExp(translateExp(cond), isStrictlyNegativePerm(thn), isStrictlyNegativePerm(els))
-        case _ => backup
+        case _ => backup()
       }
     }
 


### PR DESCRIPTION
This addresses https://github.com/viperproject/silver/issues/444 on the Carbon side and depends on a change in Silver to introduce a new kind of error and adapt test annotations.

@gauravpartha: I've implemented this now by introducing a completely new check that ``perm > none`` instead of replacing or modifying the existing ``perm >= none`` checks in the QuantifiedPermModule. Is this a good way of doing things in Carbon?
I tried a different version first (it's on branch [meilers_unfold_none](https://github.com/viperproject/carbon/tree/meilers_unfold_none)) where I instead check in QuantifiedPermModule if we're currently folding or unfolding a predicate, and then if that's the case I check the error type and make the comparison strict. That had two drawbacks: a) it felt awkward because exhaleExp and inhaleAux suddenly use some random state in the FuncPredModule, and b) it results in a different order of errors than in Silicon.
I could also imagine a third version where all methods (exhaleExp, exhaleExpBeforeAfter, exhale, exhaleConnective, invokeExhaleOnComponents, inhaleAux, ...) all get an additional boolean parameter to specify whether a value of zero is okay, and then that gets set to false in foldPredicate or unfoldPredicate. That also didn't feel good to me because I pass this one value through fifteen methods, but maybe that's preferable to duplicating the check like in this PR. What do you think?

I should mention: Both other options (where we check that the permission is non-zero when exhaling or inhaling the predicate) also have the issue that they result in a different order of checks for folds than in Silicon: For folds, we would exhale the predicate body before inhaling the predicate and checking that the permission is non-zero. Thus, if some pure constraint in the predicate is not satisfied, we'd get an error about that first, before the error for the zero-permission. In Silicon, the zero-error always comes first, which feels better to me.