### PR TITLE
Opaque function annotation

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -55,6 +55,11 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   private val assumeFunctionsAbove: Const = Const(assumeFunctionsAboveName)
   private val specialRefName = Identifier("special_ref")
   private val specialRef = Const(specialRefName)
+
+  /* limitedPostfix is appended to the actual function name to get the name of the limited function.
+   * It must be a string that cannot appear in Viper identifiers to ensure that we can easily check if a given identifier
+   * refers to the limited version of a function or not.
+   */
   private val limitedPostfix = "'"
   private val triggerFuncPostfix = "#trigger"
   private val triggerFuncNoHeapPostfix = "#triggerStateless"
@@ -319,6 +324,9 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   private def transformFuncAppsToLimitedOrTriggerForm(exp: Exp, heightToSkip : Int = -1, triggerForm: Boolean = false): Exp = {
     def transformer: PartialFunction[Exp, Option[Exp]] = {
       case FuncApp(recf, recargs, t) if recf.namespace == fpNamespace &&
+        // recf might refer to a limited function already if the function was marked as opaque.
+        // In that case, we have to drop the limited postfix, since heights contains only the original function names.
+        // We assume that any name that ends with limitedPostfix refers to a limited function (see limitedPostfix above).
         (heightToSkip == -1 || heights(if (recf.name.endsWith(limitedPostfix)) recf.name.dropRight(limitedPostfix.length) else recf.name) <= heightToSkip) =>
 
         val baseName = if (recf.name.endsWith(limitedPostfix)) recf.name.dropRight(limitedPostfix.length) else recf.name

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -297,10 +297,15 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         case _ => None}.flatten
     }
 
+    // Do not use predicate triggers if the function is annotated as opaque
+    val usePredicateTriggers = f.info.getUniqueInfo[sil.AnnotationInfo] match {
+      case Some(ai) if ai.values.contains("opaque") => false
+      case _ => true
+    }
 
     Axiom(Forall(
       stateModule.staticStateContributions() ++ args,
-      Seq(Trigger(Seq(staticGoodState,fapp))) ++ (if (predicateTriggers.isEmpty) Seq()  else Seq(Trigger(Seq(staticGoodState, triggerFuncStatelessApp(f,args map (_.l))) ++ predicateTriggers))),
+      Seq(Trigger(Seq(staticGoodState,fapp))) ++ (if (!usePredicateTriggers || predicateTriggers.isEmpty) Seq()  else Seq(Trigger(Seq(staticGoodState, triggerFuncStatelessApp(f,args map (_.l))) ++ predicateTriggers))),
       (staticGoodState && assumeFunctionsAbove(height)) ==>
         (precondition ==> (fapp === body))
     ))


### PR DESCRIPTION
Adds the ability to annotate functions as ``@opaque()``, which will result in the function body not being known by default. The precondition of the function will still aways be checked, and the postcondition of the function is always known.
Individual function applications can then be annotated with ``@reveal()`` to reveal the function definition for that specific usage. 

Example:
```
@opaque()
function isGreaterOne(i: Int): Bool
{ i > 1 }

method mDef(j: Int)
    requires j > -50
{
    assume isGreaterOne(j)
    assert j > 1 // fails
}

method mDef2(j: Int)
    requires j > -50
{
    assume @reveal() isGreaterOne(j)
    assert j > 1 // succeeds
}
```

Internally, applications of opaque functions are encoded using the existing limited version of the function. ``@reveal()`` forces the use of the normal version of the function that triggers the definitional axiom.
The equivalent Silicon PR is here: https://github.com/viperproject/silicon/pull/767