### PR TITLE
change translation of if-statement to not rely on optimizer for readable output

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -207,8 +207,9 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
         //handled by LoopModule
         Nil
       case i@sil.If(cond, thn, els) =>
+        val condTr = if(allStateAssms == TrueLit()) { translateExpInWand(cond) } else { (allStateAssms) ==> translateExpInWand(cond) }
         checkDefinedness(cond, errors.IfFailed(cond), insidePackageStmt = insidePackageStmt) ++
-        If((allStateAssms) ==> translateExpInWand(cond),
+        If(condTr,
           translateStmt(thn, statesStack, allStateAssms, insidePackageStmt),
           translateStmt(els, statesStack, allStateAssms, insidePackageStmt))
       case sil.Label(name, _) => {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -207,7 +207,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
         //handled by LoopModule
         Nil
       case i@sil.If(cond, thn, els) =>
-        val condTr = if(allStateAssms == TrueLit()) { translateExpInWand(cond) } else { (allStateAssms) ==> translateExpInWand(cond) }
+        val condTr = if(allStateAssms == TrueLit()) { translateExpInWand(cond) } else { allStateAssms ==> translateExpInWand(cond) }
         checkDefinedness(cond, errors.IfFailed(cond), insidePackageStmt = insidePackageStmt) ++
         If(condTr,
           translateStmt(thn, statesStack, allStateAssms, insidePackageStmt),


### PR DESCRIPTION
Previously, the translated condition in the if-statement translation was computed by the Scala expression `allStateAssms ==> transalteExpInWand(cond)`. In the standard case, `allStateAssms` is set to true and Carbon's Boogie optimizer gets rid of the implication's left hand side. 

Now, the translated condition is computed such that if `allStateAssms` is true, then the left hand side is removed direcly without requiring the optimizer. This produces more readable output when doing experiments where the optimizer is switched off. 