### PR TITLE
Use local variables for the old state

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -623,7 +623,6 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
     val res = sil.Result(f.typ)()
     val init : Stmt = MaybeCommentBlock("Initializing the state",
       stateModule.initBoogieState ++ (f.formalArgs map (a => allAssumptionsAboutValue(a.typ,mainModule.translateLocalVarDecl(a),true))) ++ assumeFunctionsAt(heights(f.name)))
-    val initOld : Stmt = MaybeCommentBlock("Initializing the old state", stateModule.initOldState)
     val checkPre : Stmt = checkFunctionPreconditionDefinedness(f)
     val checkExp : Stmt = if (f.isAbstract) MaybeCommentBlock("(no definition for abstract function)",Nil) else
       MaybeCommentBlock("Check definedness of function body",
@@ -632,7 +631,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
       MaybeCommentBlock("Translate function body",
       translateResult(res) := translateExp(f.body.get))
     val checkPost = checkFunctionPostconditionDefinedness(f)
-    val body : Stmt = Seq(init, initOld, checkPre, checkExp, exp, checkPost)
+    val body : Stmt = Seq(init, checkPre, checkExp, exp, checkPost)
     val definednessChecks = Procedure(Identifier(f.name + "#definedness"), args, translateResultDecl(res), body)
     checkingDefinednessOfFunction = None
     definednessChecks

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -774,10 +774,6 @@ class DefaultHeapModule(val verifier: Verifier)
   def resetBoogieState: Stmt = {
     Havoc(heapVar)
   }
-  def initOldState: Stmt = {
-    val hVar = heapVar
-    Assume(Old(hVar) === hVar)
-  }
 
   def staticStateContributions(withHeap: Boolean, withPermissions: Boolean): Seq[LocalVarDecl] = if(withHeap) Seq(LocalVarDecl(heapName, heapTyp)) else Seq()
   def currentStateContributions: Seq[LocalVarDecl] = Seq(LocalVarDecl(heap.name, heapTyp))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -82,7 +82,7 @@ class DefaultHeapModule(val verifier: Verifier)
   private val qpHeap = LocalVar(qpHeapName, heapTyp)
   private var heap: Var = originalHeap
   private def heapVar: Var = {assert (!usingOldState); heap}
-  private def heapExp: Exp = if (usingPureState) dummyHeap else (if (usingOldState) Old(heap) else heap)
+  private def heapExp: Exp = if (usingPureState) dummyHeap else heap
   private val nullName = Identifier("null")
   private val nullLit = Const(nullName)
   private val freshObjectName = Identifier("freshObj")

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -127,9 +127,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   override def stateRepositoryGet(name:String) : Option[StateSnapshot] = stateRepository.get(name)
 
   override def freshTempState(name: String, discardCurrent: Boolean = false, initialise: Boolean = false): (Stmt, StateSnapshot) = {
-    if(name == "old") {
-      sys.error("freshTempState invoked with reserved \"old\" name")
-    }
+    assert(name != "old")
 
     val previousState = new StateSnapshot(new StateComponentMapping(), usingOldState, usingPureState)
 
@@ -154,9 +152,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   private def freshTempStateKeepCurrentAux(name: String, usedForOldState: Boolean) : StateSnapshot = {
-    if(name == "old" && !usedForOldState) {
-      sys.error("freshTempStateKeepCurrent invoked with reserved \"old\" name")
-    }
+    assert(usedForOldState || name != "old")
 
     val freshState = new StateComponentMapping()
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -85,7 +85,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   def initOldState: Stmt = {
-    val freshSnapshot = freshTempStateKeepCurrent("old")
+    val freshSnapshot = freshTempStateKeepCurrentAux("old", true)
     curOldState = freshSnapshot._1
     initToCurrentStmt(freshSnapshot)
   }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -63,7 +63,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
     // initialize the state of all components and assume that afterwards the
     // whole state is good
-  val firstStmt =  components map (_.initBoogieState)
+    val firstStmt =  components map (_.initBoogieState)
     // note: this code should come afterwards, to allow the components to reset their state variables
     for (c <- components) {
       curState.put(c, c.currentStateVars)
@@ -85,12 +85,9 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   def initOldState: Stmt = {
-    curOldState = new StateComponentMapping()
-    for (c <- components) yield {
-      val exps = curState.get(c)
-      curOldState.put(c, exps) // Logic: whenever we *get* on the old state, we should wrap in "Old"
-      exps map (e => Assume(e === Old(e))): Stmt
-    }
+    val freshSnapshot = freshTempStateKeepCurrent("old")
+    curOldState = freshSnapshot._1
+    initToCurrentStmt(freshSnapshot)
   }
 
 
@@ -104,7 +101,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
         res ++= hashMap.get(c)
       }
     }
-    if(usingOldState) (res map (v => Old(v))) else res // ALEX: I think this conditional should be on the element of the StateSnapshot
+    res
   }
 
 
@@ -130,6 +127,10 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   override def stateRepositoryGet(name:String) : Option[StateSnapshot] = stateRepository.get(name)
 
   override def freshTempState(name: String, discardCurrent: Boolean = false, initialise: Boolean = false): (Stmt, StateSnapshot) = {
+    if(name.equals("old")) {
+      sys.error("freshTempState invoked with reserved \"old\" name")
+    }
+
     val previousState = new StateSnapshot(new StateComponentMapping(), usingOldState, usingPureState)
 
     curState = new StateComponentMapping() // essentially, the code below "clones" what curState should represent anyway. But, if we omit this line, we inadvertently alias the previous hash map.
@@ -149,6 +150,14 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   override def freshTempStateKeepCurrent(name: String) : StateSnapshot = {
+    freshTempStateKeepCurrentAux(name, false)
+  }
+
+  private def freshTempStateKeepCurrentAux(name: String, usedForOldState: Boolean) : StateSnapshot = {
+    if(name.equals("old") && !usedForOldState) {
+      sys.error("freshTempStateKeepCurrent invoked with reserved \"old\" name")
+    }
+
     val freshState = new StateComponentMapping()
 
     for (c <- components) yield {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -127,7 +127,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   override def stateRepositoryGet(name:String) : Option[StateSnapshot] = stateRepository.get(name)
 
   override def freshTempState(name: String, discardCurrent: Boolean = false, initialise: Boolean = false): (Stmt, StateSnapshot) = {
-    if(name.equals("old")) {
+    if(name == "old") {
       sys.error("freshTempState invoked with reserved \"old\" name")
     }
 
@@ -154,7 +154,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
   }
 
   private def freshTempStateKeepCurrentAux(name: String, usedForOldState: Boolean) : StateSnapshot = {
-    if(name.equals("old") && !usedForOldState) {
+    if(name == "old" && !usedForOldState) {
       sys.error("freshTempStateKeepCurrent invoked with reserved \"old\" name")
     }
 

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -252,10 +252,6 @@ class QuantifiedPermModule(val verifier: Verifier)
   def resetBoogieState = {
     (maskVar := zeroMask)
   }
-  def initOldState: Stmt = {
-    val mVar = maskVar
-    Assume(Old(mVar) === mVar)
-  }
 
   override def reset = {
     mask = originalMask

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -85,7 +85,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   private val originalMask = GlobalVar(maskName, maskType)
   private var mask: Var = originalMask // When reading, don't use this directly: use either maskVar or maskExp as needed
   private def maskVar : Var = {assert (!usingOldState); mask}
-  private def maskExp : Exp = if (usingPureState) zeroMask else (if (usingOldState) Old(mask) else mask)
+  private def maskExp : Exp = if (usingPureState) zeroMask else mask
   private val zeroMaskName = Identifier("ZeroMask")
   private val zeroMask = Const(zeroMaskName)
   private val zeroPMaskName = Identifier("ZeroPMask")


### PR DESCRIPTION
Before this PR, Carbon used Boogie's old state to model Viper's old state. As a result, Carbon deals with the old state differently compared to other states such as labelled old states. In particular, state components (i.e., the heap and permission modules) must explicitly wrap the currently tracked Boogie variable corresponding to the component with `old`, which is reflected as a special case in the code.

Moreover, the previous encoding is indirect because Boogie's old state conceptually does not capture Viper's state. The following encoding snippet previously used at the beginning of a method encoding illustrates this:

```
procedure p(...) {
  Mask := ZeroMask;
  assume state(Heap, Mask);
  [encoding of `inhale precondition` in `(Heap, Mask)`]
  
  assume Heap == old(Heap);
  assume Mask == old(Mask);
  
  [encoding of method body]
  ...
}
```

Viper's old state is the state *after* inhaling the precondition, while Boogie's old state is the state of the global variables right at the beginning of the Boogie procedure. The two assume statements after inhaling the precondition make sure that the two states are in-sync. The encoding is sound because the Boogie code before the assume statements does not use Boogie's old state at all. Thus, for any relevant Boogie trace, there is a corresponding one where `old(Heap)` and `old(Mask)` match the values of `Heap` and `Mask` right after inhaling the precondition.

This pull request addresses both of these problems by introducing local Boogie variables that model the old state. The new encoding corresponding to the one shown above is:

```
var oldHeap: HeapType;
var oldMask: MaskType;
Mask := ZeroMask;
assume state(Heap, Mask);
[encoding of `inhale precondition` in `(Heap, Mask)`]

oldHeap := Heap;
oldMask := Mask;

[encoding of method body]
```

This encoding is more direct. Moreover, this way of modeling the old state is the same as the approach that Carbon takes for other states (e.g., labelled old expressions). As a result, Carbon's state components (i.e., the heap and permission module) do not need to wrap their tracked variables with `old`.

Another positive consequence is that the Boogie old state does not show up in unexpected places. For example, when inhaling the postcondition `acc(x.f) && x.f == old(x.f)+1` as part of a method call, the second conjunct was previously translated to:

```
assume Heap[x,f] == old(PreCallHeap)[x,f]+1
```

Here, `PreCallHeap` has the value of the heap right before the call, which thus symbolizes the old heap during the method call. The usage of the Boogie `old` wrapper is redundant here since `PreCallHeap` is a local variable. The reason Carbon uses the `old` wrapper here is because whenever the body of an old expression is evaluated, the state is marked as being an old state, which then leads to the Carbon state components using using the `old` wrapper. In the new encoding, the state components do not use the `old` wrapper anymore (but the state is still marked as an old state in the Carbon implementation itself).



