### PR TITLE
Escape quotation marks in error messages in Boogie output

### DIFF
--- a/src/main/scala/viper/carbon/boogie/PrettyPrinter.scala
+++ b/src/main/scala/viper/carbon/boogie/PrettyPrinter.scala
@@ -183,7 +183,7 @@ class PrettyPrinter(n: Node) extends BracketPrettyPrinter {
   }
 
   def showError(error: VerificationError, id: Int) = {
-    s"${error.readableMessage} [$id]"
+    s"${error.readableMessage.replaceAll("\"", "'")} [$id]"
   }
 
   def showBlock(stmt: Stmt) = {


### PR DESCRIPTION
This fixes #504 