### PR TITLE
Fixing injectivity checks for QPs with multiple quantified variables

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@
 //
 // Copyright (c) 2011-2019 ETH Zurich.
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -624,7 +624,7 @@ class QuantifiedPermModule(val verifier: Verifier)
             //injectivity assertion
             val v2s = translatedLocals.map(translatedLocal => LocalVarDecl(Identifier(translatedLocal.name.name), translatedLocal.typ))
             var triggerFunApp2 : FuncApp = triggerFunApp
-            var notEquals : Exp = TrueLit()
+            var notEquals : Exp = FalseLit()
             var translatedPerms2 = translatedPerms
             var translatedCond2 = translatedCond
             var translatedRecv2 = translatedRecv
@@ -633,7 +633,7 @@ class QuantifiedPermModule(val verifier: Verifier)
               translatedPerms2 = translatedPerms2.replace(translatedLocals(i).l, v2s(i).l)
               translatedCond2 = translatedCond2.replace(translatedLocals(i).l, v2s(i).l)
               translatedRecv2 = translatedRecv2.replace(translatedLocals(i).l, v2s(i).l)
-              notEquals = notEquals && (translatedLocals(i).l !== v2s(i).l)
+              notEquals = notEquals || (translatedLocals(i).l !== v2s(i).l)
             }
             val is_injective = Forall( translatedLocals++v2s,validateTriggers(translatedLocals++v2s, Seq(Trigger(Seq(triggerFunApp, triggerFunApp2)))),(  notEquals &&  translatedCond && translatedCond2 && permGt(translatedPerms, noPerm) && permGt(translatedPerms2, noPerm)) ==> (translatedRecv !== translatedRecv2))
             val reas = reasons.QPAssertionNotInjective(fieldAccess)
@@ -811,13 +811,13 @@ class QuantifiedPermModule(val verifier: Verifier)
             //assert injectivity of inverse function:
             val translatedLocals2 = translatedLocals.map(translatedLocal => LocalVarDecl(Identifier(translatedLocal.name.name), translatedLocal.typ)) //new varible
 
-            var unequalities : Exp = TrueLit()
+            var unequalities : Exp = FalseLit()
             var translatedCond2 = translatedCond
             var translatedPerms2 = translatedPerms
             var translatedArgs2 = translatedArgs
             var triggerFunApp2 = triggerFunApp
             for (i <- 0 until translatedLocals.length) {
-              unequalities = unequalities && (translatedLocals(i).l.!==(translatedLocals2(i).l))
+              unequalities = unequalities || (translatedLocals(i).l.!==(translatedLocals2(i).l))
               translatedCond2 = translatedCond2.replace(translatedLocals(i).l, translatedLocals2(i).l)
               translatedPerms2 = translatedPerms2.replace(translatedLocals(i).l, translatedLocals2(i).l)
               translatedArgs2 = translatedArgs2.map(a => a.replace(translatedLocals(i).l, translatedLocals2(i).l))
@@ -1190,7 +1190,7 @@ class QuantifiedPermModule(val verifier: Verifier)
            //injectivity assertion
            val v2s = translatedLocals.map(translatedLocal => LocalVarDecl(Identifier(translatedLocal.name.name), translatedLocal.typ))
            var triggerFunApp2 = FuncApp(triggerFun.name, translatedLocals.map(v => LocalVar(v.name, v.typ)), triggerFun.typ)
-           var notEquals: Exp = TrueLit()
+           var notEquals: Exp = FalseLit()
            var translatedPerms2 = translatedPerms
            var translatedCond2 = translatedCond
            var translatedRecv2 = translatedRecv
@@ -1199,7 +1199,7 @@ class QuantifiedPermModule(val verifier: Verifier)
              translatedPerms2 = translatedPerms2.replace(translatedLocals(i).l, v2s(i).l)
              translatedCond2 = translatedCond2.replace(translatedLocals(i).l, v2s(i).l)
              translatedRecv2 = translatedRecv2.replace(translatedLocals(i).l, v2s(i).l)
-             notEquals = notEquals && (translatedLocals(i).l !== v2s(i).l)
+             notEquals = notEquals || (translatedLocals(i).l !== v2s(i).l)
            }
            val is_injective = Forall(translatedLocals ++ v2s, validateTriggers(translatedLocals ++ v2s, Seq(Trigger(Seq(triggerFunApp2)))), (notEquals && translatedCond && translatedCond2 && permGt(translatedPerms, noPerm) && permGt(translatedPerms2, noPerm)) ==> (translatedRecv !== translatedRecv2))
 
@@ -1367,13 +1367,13 @@ class QuantifiedPermModule(val verifier: Verifier)
 
            val triggerFunApp = FuncApp(triggerFun.name, translatedLocals.map(translatedLocal => LocalVar(translatedLocal.name, translatedLocal.typ)), triggerFun.typ)
 
-           var unequalities : Exp = TrueLit()
+           var unequalities : Exp = FalseLit()
            var translatedCond2 = translatedCond
            var translatedPerms2 = translatedPerms
            var translatedArgs2 = translatedArgs
            var triggerFunApp2 = triggerFunApp
            for (i <- 0 until translatedLocals.length) {
-             unequalities = unequalities && (translatedLocals(i).l.!==(translatedLocals2(i).l))
+             unequalities = unequalities || (translatedLocals(i).l.!==(translatedLocals2(i).l))
              translatedCond2 = translatedCond2.replace(translatedLocals(i).l, translatedLocals2(i).l)
              translatedPerms2 = translatedPerms2.replace(translatedLocals(i).l, translatedLocals2(i).l)
              translatedArgs2 = translatedArgs2.map(a => a.replace(translatedLocals(i).l, translatedLocals2(i).l))


### PR DESCRIPTION
This fixes #378. The injectivity check is not actually missing, but it's incorrect (also for fields).

For a QP of the form ``forall x, y :: cond ==> P(e1, e2)``, the current code essentially generated the following injectivity check: 
```
assert forall x, x', y, y' :: (x != x' && y != y') && cond && cond' ==> (e1 != e1' || e2 != e2')
```

This is incorrect. We need to check that if the value of *any* quantified variable changes, we get a different tuple of receiver expressions, but we're checking that if the values of *all* quantified variables change, we get a different tuple. Essentially, we need to check that the receiver tuple is injective in all quantified variables, but the current check also succeeds if it's injective only in one of them.

So this PR changes the check to
```
assert forall x, x', y, y' :: (x != x' || y != y') && cond && cond' ==> (e1 != e1' || e2 != e2')
```