### PR TITLE
Desugaring quasihavocall to an exhale-inhale pair

### DIFF
--- a/src/main/scala/viper/carbon/CarbonVerifier.scala
+++ b/src/main/scala/viper/carbon/CarbonVerifier.scala
@@ -161,8 +161,8 @@ case class CarbonVerifier(override val reporter: Reporter,
       program.shallowCollect(
         n =>
           n match {
-            case q: Quasihavocall =>
-              ConsistencyError("Carbon does not support quasihavocall", q.pos)
+            case q@Quasihavocall(_, _, MagicWand(_, _)) =>
+              ConsistencyError("Carbon does not support quasihavocall of magic wands", q.pos)
             case q@Quasihavoc(_, MagicWand(_, _)) =>
               ConsistencyError("Carbon does not support quasihavoc of magic wands", q.pos)
           }


### PR DESCRIPTION
This PR adds support for ``quasihavocall`` similar to the existing support for ``quasihavoc``, namely by desugaring it into an exhale-inhale pair (which unfortunately means that magic wands cannot be supported). 

```
quasihavoc vars :: cond ==> P(args)
```

is desugared to 

```
label perm_temp_quasihavoc_
exhale forall vars :: { P(args) } cond ==> acc(P(args), old[perm_temp_quasihavoc_](perm(P(args))))
inhale forall vars :: { P(args) } cond ==> acc(P(args), old[perm_temp_quasihavoc_](perm(P(args))))
```