### PR TITLE
Avoiding Viper functions in hashsets and as keys in hashmaps

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -193,7 +193,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   }
 
   def reset() = {
-    heights = Functions.heights(verifier.program).map{case (f, h) => f.name -> h}
+    heights = Functions.heights(verifier.program)
     tmpStateId = -1
     duringFold = false
     foldInfo = null


### PR DESCRIPTION
Adapting Carbon to the changes in https://github.com/viperproject/silver/pull/867.