### PR TITLE
Clean up fold encoding

### DIFF
--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -638,7 +638,6 @@ class DefaultHeapModule(val verifier: Verifier)
                 Havoc(newVersion) ++
                 currentHeapAssignUpdate(loc, newVersion)
 
-              If(UnExp(Not,hasDirectPerm(loc)), resetPredicateInfo, Nil) ++
                 addPermissionToPMask(loc) ++ stateModule.assumeGoodState}  )
           case sil.FieldAssign(lhs, rhs) =>
             if(usingOldState) sys.error("heap module: field is assigned while using old state")


### PR DESCRIPTION
Since we now check the permission amount for strict positivity in fold statements, it is unnecessary to check if the state has zero direct permission to the predicate instance afterwards and update the snapshot if true.