### PR TITLE
Implementing exhaleExt for quantified permissions

### DIFF
--- a/src/main/scala/viper/carbon/boogie/boogie.scala
+++ b/src/main/scala/viper/carbon/boogie/boogie.scala
@@ -263,6 +263,13 @@ object MaybeForall {
     else Forall(vars, triggers, exp)
   }
 }
+
+object MaybeExists {
+  def apply(vars: Seq[LocalVarDecl], triggers: Seq[Trigger], exp: Exp) = {
+    if (vars.isEmpty) exp
+    else Exists(vars, triggers, exp)
+  }
+}
 case class Exists(vars: Seq[LocalVarDecl], triggers: Seq[Trigger], exp: Exp, weight: Option[Int] = None) extends QuantifiedExp
 case class Trigger(exps: Seq[Exp]) extends Node
 

--- a/src/main/scala/viper/carbon/modules/HeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/HeapModule.scala
@@ -183,6 +183,9 @@ trait HeapModule extends Module with CarbonStateComponent {
   // adds permission to field e to the secondary mask of the wand
   def addPermissionToWMask(wMask: Exp, e: sil.Exp): Stmt
 
+  // adds all locations that have positive permission in the given mask to the secondary mask of the wand
+  def addPermissionToWMaskQuant(wMask: Exp, takeMask: Exp): Stmt
+
   // If expression evaluates to true then resultHeap is the sum of of heap1, where mask1 is defined,
   // and heap2, where mask2 is defined.
   def sumHeap(resultHeap: Exp, heap1: Exp, mask1: Exp, heap2: Exp, mask2: Exp): Exp

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -137,6 +137,8 @@ trait PermModule extends Module with CarbonStateComponent {
     */
   def sumMask(resultMask: Seq[Exp], summandMask1: Seq[Exp], summandMask2: Seq[Exp]) : Exp
 
+  def minMask(mask1: Seq[Exp], mask2: Seq[Exp]): Exp
+
     /** returns a mask and the returned statement ensures that the mask  has non-zero permission at rcv.loc and zero
       * permission at all other location
       * this should only be used temporarily, i.e. if there are two calls to this then the previous tempMask returned
@@ -161,5 +163,9 @@ trait PermModule extends Module with CarbonStateComponent {
   def setCheckReadPermissionOnly(readOnly: Boolean): Boolean
 
   def assumePermUpperBounds(doAssume: Boolean): Stmt
+
+  def hasSomePerm(mask: Exp): Exp
+
+  def subtractMask(op1: Exp, op2: Exp, target: Var): Stmt
 
 }

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -166,9 +166,11 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def assumePermUpperBounds(doAssume: Boolean): Stmt
 
-  def hasSomePerm(mask: Exp, resource: Exp): Exp
+  def hasSomePerm(mask: Exp, fieldType: Type): Exp
 
   def subtractMask(op1: Exp, op2: Exp, target: Var): Stmt
+
+  def goodMask(msk: Exp): Exp
 
   def addQPFunctions(qvars: Seq[LocalVarDecl], argumentDecls: Seq[LocalVarDecl]):(Seq[Func],Func,Func)
 

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -107,6 +107,8 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def currentPermission(rcv:Exp, loc:Exp):Exp
 
+  def currentPermission(mask: Exp, rcv: Exp, location: Exp): Exp
+
   /**these methods are for experimental purposes, not yet finalized **/
   /*def beginSumMask : Stmt
 
@@ -164,8 +166,12 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def assumePermUpperBounds(doAssume: Boolean): Stmt
 
-  def hasSomePerm(mask: Exp): Exp
+  def hasSomePerm(mask: Exp, resource: Exp): Exp
 
   def subtractMask(op1: Exp, op2: Exp, target: Var): Stmt
+
+  def addQPFunctions(qvars: Seq[LocalVarDecl], argumentDecls: Seq[LocalVarDecl]):(Seq[Func],Func,Func)
+
+  def validateTriggers(vars:Seq[LocalVarDecl], triggers:Seq[Trigger]):Seq[Trigger]
 
 }

--- a/src/main/scala/viper/carbon/modules/PermModule.scala
+++ b/src/main/scala/viper/carbon/modules/PermModule.scala
@@ -42,6 +42,8 @@ trait PermModule extends Module with CarbonStateComponent {
    */
   def permissionPositive(permission: Exp, zeroOK : Boolean = false): Exp
 
+  def permissionZero(permission: Exp): Exp
+
   def conservativeIsPositivePerm(e: sil.Exp): Boolean
 
   /**
@@ -166,7 +168,7 @@ trait PermModule extends Module with CarbonStateComponent {
 
   def assumePermUpperBounds(doAssume: Boolean): Stmt
 
-  def hasSomePerm(mask: Exp, fieldType: Type): Exp
+  def hasSomePerm(mask: Exp, vars: Seq[LocalVarDecl], rcv: Exp, fld: Exp): Exp
 
   def subtractMask(op1: Exp, op2: Exp, target: Var): Stmt
 

--- a/src/main/scala/viper/carbon/modules/TransferEntity.scala
+++ b/src/main/scala/viper/carbon/modules/TransferEntity.scala
@@ -6,10 +6,9 @@
 
 package viper.carbon.modules
 
-import viper.carbon.boogie.Exp
+import viper.carbon.boogie.{Exp, LocalVar}
 import viper.silver.ast.LocationAccess
 import viper.silver.verifier.{PartialVerificationError, VerificationError, reasons}
-
 import viper.silver.{ast => sil}
 
 sealed trait TransferableEntity {
@@ -39,10 +38,18 @@ object TransferableAccessPred {
 }
 
 case class TransferableFieldAccessPred(rcv: Exp, loc:Exp, transferAmount: Exp,originalSILExp: sil.AccessPredicate) extends TransferableAccessPred
+case class QuantifiedTransferableFieldAccessPred(qvars: Seq[LocalVar], cond: Exp, rcv: Exp, loc:Exp, transferAmount: Exp, originalSILExp: sil.AccessPredicate) extends TransferableAccessPred
 
 case class TransferablePredAccessPred(rcv: Exp, loc:Exp, transferAmount: Exp,originalSILExp: sil.AccessPredicate) extends TransferableAccessPred
+case class QuantifiedTransferablePredAccessPred(qvars: Seq[LocalVar], cond: Exp, rcv: Exp, loc:Exp, transferAmount: Exp,originalSILExp: sil.AccessPredicate) extends TransferableAccessPred
 
 case class TransferableWand(rcv:Exp, loc: Exp, transferAmount: Exp,originalSILExp: sil.MagicWand) extends TransferableEntity {
+  override def transferError(error: PartialVerificationError): VerificationError = {
+    error.dueTo(reasons.MagicWandChunkNotFound(originalSILExp))
+  }
+}
+
+case class QuantifiedTransferableWand(qvars: Seq[LocalVar], cond: Exp, rcv:Exp, loc: Exp, transferAmount: Exp,originalSILExp: sil.MagicWand) extends TransferableEntity {
   override def transferError(error: PartialVerificationError): VerificationError = {
     error.dueTo(reasons.MagicWandChunkNotFound(originalSILExp))
   }

--- a/src/main/scala/viper/carbon/modules/components/TransferComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/TransferComponent.scala
@@ -32,6 +32,8 @@ trait TransferComponent extends Component {
    */
   def transferAdd(e:TransferableEntity, cond: Exp): Stmt
 
+  def transferAddQuant(toAddMask: Exp, cond: Exp): Stmt
+
   /**
    *
    * @param e
@@ -39,4 +41,6 @@ trait TransferComponent extends Component {
    * @return  statement which removes the expression e to the current state (for example permissions, wand)
    */
   def transferRemove(e:TransferableEntity, cond:Exp): Stmt
+
+  def transferRemoveQuant(toRemoveMask: Exp, cond: Exp): Stmt
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -694,6 +694,23 @@ class DefaultHeapModule(val verifier: Verifier)
         Statements.EmptyStmt
     }
   }
+
+  override def addPermissionToWMaskQuant(wMaskField: Exp, takeMask: Exp): Stmt = {
+    if(usingOldState) { sys.error("Updating wand mask while using old state") }
+    // TODO: for transferred predicate instances, the locations in the predicates' footprints
+    // (i.e., their secondary masks) are not propagated to the wand mask here, in contrast to
+    // the non-quantified case in addPermissionToWMask.
+    val newPMask = LocalVar(Identifier("newPMask"), pmaskType)
+    val obj = LocalVarDecl(Identifier("o")(axiomNamespace), refType)
+    val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
+    val pm1 = lookup(wandMask(wMaskField), obj.l, field.l, true)
+    val pm2 = lookup(newPMask, obj.l, field.l, true)
+    val transferredPerm = permModule.currentPermission(takeMask, obj.l, field.l)
+    Havoc(newPMask) ++
+      Assume(Forall(Seq(obj, field), Seq(Trigger(pm2)), (pm1 || permModule.permissionPositive(transferredPerm)) ==> pm2)) ++
+      curHeapAssignUpdatePredWandMask(wMaskField, newPMask)
+  }
+
   /**
    * Adds the permissions from the body of a predicate to its permission mask.
    */

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -558,8 +558,15 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
       case w: sil.MagicWand =>
         (heapModule.isWandField(fldp) && (heapModule.getPredicateOrWandId(fldp) === IntLit(heapModule.getPredicateOrWandId(wandModule.getWandName(w)))))
     })
+    // The receiver may only be constrained here for predicates and wands, where it is the constant null.
+    // For fields, the receiver expression mentions the quantified variable (not in scope here); receivers
+    // of the right field that are not in the QP's range are already handled by independentResource.
+    val independentCond: Exp = accPred match {
+      case _: sil.FieldAccessPredicate => isRightFieldType(field.l).not
+      case _ => (obj.l !== heapModule.translateNull) || isRightFieldType(field.l).not
+    }
     val independentLocations = Assume(Forall(Seq(obj, field), Seq(Trigger(currentPermission(obj.l, field.l)), Trigger(currentPermission(transferAmountLocalQuant, obj.l, field.l))),
-      ((obj.l !== translatedReceiver) || isRightFieldType(field.l).not) ==>
+      independentCond ==>
         (permModule.permissionZero(currentPermission(transferAmountLocalQuant, obj.l, field.l)))))
     val validMask = Assume(permModule.goodMask(transferAmountLocalQuant))
     //same resource, but not satisfying the condition
@@ -768,8 +775,9 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
         val curPermTopQuant: Exp =  permModule.currentMask.head // permModule.currentPermission(e.rcv, e.loc)
         val removeFromTop = heapModule.beginExhale ++
           (components flatMap (_.transferRemoveQuant(transferAmountLocalQuant,used.boolVar))) ++
-          {if(top != OPS){ // Sets the transferred field in secondary mask of the wand to true ,eg., Heap[null, w#sm][x, f] := true
-            heapModule.addPermissionToWMask(getWandFtSmRepresentation(currentWand, 1), e.originalSILExp)
+          {if(top != OPS){ // Sets all locations transferred in this round (positive perm in the transferred mask)
+            // to true in the secondary mask of the wand
+            heapModule.addPermissionToWMaskQuant(getWandFtSmRepresentation(currentWand, 1), transferAmountLocalQuant)
           }else{
             Statements.EmptyStmt
           }
@@ -796,15 +804,12 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
         val addToUsed = (components flatMap (_.transferAddQuant(transferAmountLocalQuant,used.boolVar))) ++
           (used.boolVar := used.boolVar&&stateModule.currentGoodState)
 
+        // equate the values of the used state's heap with the top state's heap on all locations
+        // that were transferred in this round (the mask of transferred permissions guards the
+        // equality pointwise, so this is a no-op if nothing was transferred)
         val equateStmt:Stmt = e match {
-          case QuantifiedTransferableFieldAccessPred(vrs, cnd, rcv,loc,_,_) =>
-            val (tempMask, initTMaskStmt) = permModule.tempInitMask(rcv, loc)
-            initTMaskStmt ++
-              (used.boolVar := used.boolVar && heapModule.identicalOnKnownLocations(topHeap, tempMask))
-          case TransferablePredAccessPred(rcv,loc,_,_) =>
-            val (tempMask, initTMaskStmt) = permModule.tempInitMask(rcv,loc)
-            initTMaskStmt ++
-              (used.boolVar := used.boolVar&&heapModule.identicalOnKnownLocations(topHeap,tempMask))
+          case _: QuantifiedTransferableFieldAccessPred | _: QuantifiedTransferablePredAccessPred =>
+            used.boolVar := used.boolVar && heapModule.identicalOnKnownLocations(topHeap, Seq(transferAmountLocalQuant))
           case _ => Nil
         }
 
@@ -812,19 +817,24 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
 
 
         //transfer from top to used state
+        //Note: in contrast to the non-quantified case, the transfer is not guarded by checks that
+        //some permission is actually needed resp. transferred. Such guards would be existential
+        //quantifiers over the needed resp. transferred mask, and the resulting case splits are
+        //poison for the SMT solver (to rule a branch out, it has to refute an existential by
+        //re-deriving the pointwise contents of all masks involved, along every path).
+        //Instead, the transfer is executed unconditionally: since the transferred amount is the
+        //pointwise minimum of the needed mask and the top state's mask, all updates below are
+        //no-ops when there is nothing to transfer.
         MaybeCommentBlock("transfer code for top state of stack",
           Comment("accumulate constraints which need to be satisfied for transfer to occur") ++ definednessTop ++
             Comment("actual code for the transfer from current state on stack") ++
-            If( (allStateAssms&&used.boolVar) && boolTransferTop && hasSomePerm(neededLocalQuant),
+            If( (allStateAssms&&used.boolVar) && boolTransferTop,
               (curpermLocalQuant := curPermTopQuant) ++
                 minStmt ++
-                If(hasSomePerm(transferAmountLocalQuant),
-                  Seq(tempAmountQuant := neededLocalQuant, subtractMask(tempAmountQuant, transferAmountLocalQuant, neededLocalQuant)) ++
-                    addToUsed ++
-                    equateStmt ++
-                    removeFromTop,
-
-                  Nil),
+                Seq(tempAmountQuant := neededLocalQuant, subtractMask(tempAmountQuant, transferAmountLocalQuant, neededLocalQuant)) ++
+                addToUsed ++
+                equateStmt ++
+                removeFromTop,
 
               Nil
             )

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -540,24 +540,30 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     val triggerForPermissionUpdateAxioms = Seq(Trigger(currentPermission(transferAmountLocalQuant, generalReceiver, generalLocation)) /*,Trigger(currentPermission(mask, translateNull, general_location)),Trigger(invFunApp)*/)
     val permissionsMap = Assume(MaybeForall(freshFormalBoogieDecls, triggerForPermissionUpdateAxioms, ((condInv && (permModule.permissionPositive(permInv)) && rangeFunApp) ==> (conjoinedInverseAssumptions && (currentPermission(transferAmountLocalQuant, generalReceiver, generalLocation) === permInv)))))
 
+    val hasSomePerm = (msk: Exp) => MaybeExists(
+      freshFormalBoogieDecls,
+      Seq(Trigger(currentPermission(msk, generalReceiver, generalLocation))),
+      permModule.permissionPositive(currentPermission(msk, generalReceiver, generalLocation)))
+
     //Assume no change for independent locations: different predicate/wand or different resource type
     val obj = LocalVarDecl(Identifier("o")(transferNamespace), heapModule.refType)
     val field = LocalVarDecl(Identifier("f")(transferNamespace), heapModule.fieldType)
     val fieldVar = LocalVar(Identifier("f")(transferNamespace), heapModule.fieldType)
-    val isRightFieldType = accPred match {
+    val isRightFieldType = ((fldp: Exp) => accPred match {
       case sil.FieldAccessPredicate(sil.FieldAccess(rcv, fld), _) =>
-        (field.l === translatedResource)
+        (fldp === translatedResource)
       case sil.PredicateAccessPredicate(sil.PredicateAccess(_, predname), _) =>
-        //(heapModule.isPredicateField(fieldVar) && (heapModule.getPredicateOrWandId(fieldVar) === IntLit(heapModule.getPredicateOrWandId(predname))))
-        (MaybeExists(freshFormalBoogieDecls, Seq(Trigger(generalLocation)), generalLocation === field.l))
+        (heapModule.isPredicateField(fldp) && (heapModule.getPredicateOrWandId(fldp) === IntLit(heapModule.getPredicateOrWandId(predname))))
+        //(MaybeExists(freshFormalBoogieDecls, Seq(Trigger(generalLocation)), generalLocation === field.l))
       case w: sil.MagicWand =>
-        (heapModule.isWandField(fieldVar) && (heapModule.getPredicateOrWandId(fieldVar) === IntLit(heapModule.getPredicateOrWandId(wandModule.getWandName(w)))))
-    }
+        (heapModule.isWandField(fldp) && (heapModule.getPredicateOrWandId(fldp) === IntLit(heapModule.getPredicateOrWandId(wandModule.getWandName(w)))))
+    })
     val independentLocations = Assume(Forall(Seq(obj, field), Seq(Trigger(currentPermission(obj.l, field.l)), Trigger(currentPermission(transferAmountLocalQuant, obj.l, field.l))),
-      ((obj.l !== translatedReceiver) || isRightFieldType.not) ==>
-        (permModule.permissionPositive(currentPermission(transferAmountLocalQuant, obj.l, field.l)).not)))
+      ((obj.l !== translatedReceiver) || isRightFieldType(field.l).not) ==>
+        (permModule.permissionZero(currentPermission(transferAmountLocalQuant, obj.l, field.l)))))
+    val validMask = Assume(permModule.goodMask(transferAmountLocalQuant))
     //same resource, but not satisfying the condition
-    val independentResource = Assume(MaybeForall(freshFormalBoogieDecls, triggerForPermissionUpdateAxioms, ((condInv && (permModule.permissionPositive(permInv)) && rangeFunApp).not) ==> (permModule.permissionPositive(currentPermission(transferAmountLocalQuant, generalReceiver, generalLocation)).not)))
+    val independentResource = Assume(MaybeForall(freshFormalBoogieDecls, triggerForPermissionUpdateAxioms, ((condInv && (permModule.permissionPositive(permInv)) && rangeFunApp).not) ==> (permModule.permissionZero(currentPermission(transferAmountLocalQuant, generalReceiver, generalLocation)))))
 
 
     //AS: TODO: it would be better to use the Boogie representation of a predicate/wand instance as the canonical representation here (i.e. the function mapping to a field in the Boogie heap); this would avoid the disjunction of arguments used below. In addition, this could be used as a candidate trigger in tr1 code above. See issue 242
@@ -600,7 +606,7 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
       CommentBlock("check if receiver " + accPred.toString + " is injective", injectiveAssertion) ++
       CommentBlock("assumptions for inverse of receiver " + accPred.toString, Assume(invAssm1) ++ Assume(invAssm2)) ++
       CommentBlock("assume permission for relevant locations", permissionsMap ++ independentResource) ++
-      CommentBlock("assume permission for independent locations ", independentLocations)
+      CommentBlock("assume permission for independent locations ", independentLocations ++ validMask)
 
 
     val transferEntity = e match {
@@ -629,7 +635,7 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
       MaybeCommentBlock("checking if access predicate defined in used state",
         If(allStateAssms&&used.boolVar,expModule.checkDefinedness(e, mainError, insidePackageStmt = true),Statements.EmptyStmt))
 
-    val transferRest = transferAccQuant(states,used, transferEntity,allStateAssms, mainError, havocHeap)
+    val transferRest = transferAccQuant(states,used, transferEntity, hasSomePerm, allStateAssms, mainError, havocHeap)
     val stmt = definedness++ res1 /*++ nullCheck*/ ++ initPermVars ++ transferRest
 
     val unionStmt = updateUnion()
@@ -734,7 +740,7 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
   }
 }
 
-  private def transferAccQuant(states: List[StateRep], used:StateRep, e: TransferableEntity, allStateAssms: Exp, mainError: PartialVerificationError, havocHeap: Boolean = true):Stmt = {
+  private def transferAccQuant(states: List[StateRep], used:StateRep, e: TransferableEntity, hasSomePerm: Exp => Exp, allStateAssms: Exp, mainError: PartialVerificationError, havocHeap: Boolean = true):Stmt = {
     val resFieldType = e match {
       case qf: QuantifiedTransferableFieldAccessPred =>
         val t = typeModule.translateType(qf.originalSILExp.asInstanceOf[sil.FieldAccessPredicate].loc.field.typ)
@@ -799,7 +805,7 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
             val (tempMask, initTMaskStmt) = permModule.tempInitMask(rcv,loc)
             initTMaskStmt ++
               (used.boolVar := used.boolVar&&heapModule.identicalOnKnownLocations(topHeap,tempMask))
-          //case _ => Nil
+          case _ => Nil
         }
 
         val translatedResource = e.loc
@@ -809,10 +815,10 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
         MaybeCommentBlock("transfer code for top state of stack",
           Comment("accumulate constraints which need to be satisfied for transfer to occur") ++ definednessTop ++
             Comment("actual code for the transfer from current state on stack") ++
-            If( (allStateAssms&&used.boolVar) && boolTransferTop && hasSomePerm(neededLocalQuant, resFieldType),
+            If( (allStateAssms&&used.boolVar) && boolTransferTop && hasSomePerm(neededLocalQuant),
               (curpermLocalQuant := curPermTopQuant) ++
                 minStmt ++
-                If(hasSomePerm(transferAmountLocalQuant, resFieldType),
+                If(hasSomePerm(transferAmountLocalQuant),
                   Seq(tempAmountQuant := neededLocalQuant, subtractMask(tempAmountQuant, transferAmountLocalQuant, neededLocalQuant)) ++
                     addToUsed ++
                     equateStmt ++
@@ -822,9 +828,9 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
 
               Nil
             )
-        ) ++ transferAccQuant(xs,used,e,allStateAssms, mainError, havocHeap) //recurse over rest of states
+        ) ++ transferAccQuant(xs,used,e, hasSomePerm, allStateAssms, mainError, havocHeap) //recurse over rest of states
       case Nil =>
-        Assert((allStateAssms&&used.boolVar) ==> (hasSomePerm(neededLocalQuant, resFieldType).not),
+        Assert((allStateAssms&&used.boolVar) ==> (hasSomePerm(neededLocalQuant).not),
           e.transferError(mainError))
       /**
         * actually only curPermUsed === permLocal would be sufficient if the transfer is written correctly, since

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -450,16 +450,9 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     //translate components
     val (translatedCond, translatedArgs) = (expModule.translateExp(renamingCond), renamingArgs.map(expModule.translateExp))
     val translatedLocals = vsFresh.map(v => mainModule.translateLocalVarDecl(v))
-    val (translatedPerms, stmts, wildcard) = {
-      if (false /* conservativeIsWildcardPermission(perms) */) {
-        //isWildcard = true
-        //val w = LocalVar(Identifier("wildcard"), Real)
-        //(w, LocalVarWhereDecl(w.name, w > RealLit(0)) :: Havoc(w) :: Nil, w)
-        (???, ???, ???)
-      } else {
-        (expModule.translateExp(renamingPerms), Nil, null)
-      }
-    }
+    // wildcard permissions are not supported inside package statements and are rejected
+    // upfront via permModule.containsWildCard (see DefaultExhaleModule.exhaleConnective)
+    val translatedPerms = expModule.translateExp(renamingPerms)
 
     val translatedReceiver = resource match {
       case _: sil.Field => translatedArgs.head
@@ -511,16 +504,6 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     //check that the permission expression is non-negative for all predicates/wands satisfying the condition
     val permPositive = Assert(MaybeForall(freshFormalBoogieDecls, Trigger(invFunApps), (condInv && rangeFunApp) ==> permissionPositive(permInv, true)),
       mainError.dueTo(reasons.NegativePermission(permAmount)))
-
-    //if we exhale a wildcard permission, assert that we hold some permission to all affected locations and restrict the wildcard value
-    val wildcardAssms: Stmt =
-      if (false /* isWildcard */) {
-        //Assert(Forall(translatedLocals, Seq(), translatedCond ==> (permissionPositive(currentPermission(translatedReceiver, translatedResource)))), mainError.dueTo(reason)) ++
-          //Assume(Forall(translatedLocals, Seq(), translatedCond ==> (wildcard < currentPermission(translatedReceiver, translatedResource))))
-        Nil
-      } else {
-        Nil
-      }
 
     //Assume map update for affected locations
     val (generalReceiver, generalLocation) = accPred match {
@@ -608,7 +591,6 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     val injectiveAssertion = Assert(Forall((translatedLocals ++ translatedLocals2), injectTrigger, injectiveCond ==> ineqExpr), err)
 
     val res1 = Havoc(transferAmountLocalQuant) ++ Assume(permModule.goodMask(transferAmountLocalQuant)) ++
-      MaybeComment("wildcard assumptions", stmts ++ wildcardAssms) ++
       CommentBlock("check that the permission amount is positive", permPositive) ++
       CommentBlock("check if receiver " + accPred.toString + " is injective", injectiveAssertion) ++
       CommentBlock("assumptions for inverse of receiver " + accPred.toString, Assume(invAssm1) ++ Assume(invAssm2)) ++

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -551,7 +551,6 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     val independentLocations = Assume(Forall(Seq(obj, field), Seq(Trigger(currentPermission(obj.l, field.l)), Trigger(currentPermission(transferAmountLocalQuant, obj.l, field.l))),
       independentCond ==>
         (permModule.permissionZero(currentPermission(transferAmountLocalQuant, obj.l, field.l)))))
-    val validMask = Assume(permModule.goodMask(transferAmountLocalQuant))
     //same resource, but not satisfying the condition
     val independentResource = Assume(MaybeForall(freshFormalBoogieDecls, triggerForPermissionUpdateAxioms, ((condInv && (permModule.permissionPositive(permInv)) && rangeFunApp).not) ==> (permModule.permissionZero(currentPermission(transferAmountLocalQuant, generalReceiver, generalLocation)))))
 
@@ -590,12 +589,12 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     }
     val injectiveAssertion = Assert(Forall((translatedLocals ++ translatedLocals2), injectTrigger, injectiveCond ==> ineqExpr), err)
 
-    val res1 = Havoc(transferAmountLocalQuant) ++ Assume(permModule.goodMask(transferAmountLocalQuant)) ++
+    val res1 = Havoc(transferAmountLocalQuant) ++
       CommentBlock("check that the permission amount is positive", permPositive) ++
       CommentBlock("check if receiver " + accPred.toString + " is injective", injectiveAssertion) ++
       CommentBlock("assumptions for inverse of receiver " + accPred.toString, Assume(invAssm1) ++ Assume(invAssm2)) ++
       CommentBlock("assume permission for relevant locations", permissionsMap ++ independentResource) ++
-      CommentBlock("assume permission for independent locations ", independentLocations ++ validMask)
+      CommentBlock("assume permission for independent locations ", independentLocations)
 
 
     val transferEntity = e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -452,14 +452,14 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     val translatedLocals = vsFresh.map(v => mainModule.translateLocalVarDecl(v))
     // wildcard permissions are not supported inside package statements and are rejected
     // upfront via permModule.containsWildCard (see DefaultExhaleModule.exhaleConnective)
-    val translatedPerms = expModule.translateExp(renamingPerms)
+    val translatedPerms = expModule.translateExpInWand(renamingPerms)
 
     val translatedReceiver = resource match {
       case _: sil.Field => translatedArgs.head
       case _ => heapModule.translateNull
     }
     val translatedResource = heapModule.translateResource(renamingResAcc)
-    val translatedTriggers: Seq[Trigger] = renamedTriggers.map(trigger => (Trigger(trigger.exps.map(x => expModule.translateExp(x)))))
+    val translatedTriggers: Seq[Trigger] = renamedTriggers.map(trigger => (Trigger(trigger.exps.map(x => expModule.translateExpInWand(x)))))
 
     val (invFuns, rangeFun, triggerFun) = addQPFunctions(translatedLocals, freshFormalBoogieDecls)
     val funApps = invFuns.map(invFun => FuncApp(invFun.name, translatedArgs, invFun.typ))

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -448,7 +448,7 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
     val renamedTriggers: Seq[sil.Trigger] = e.triggers.map(trigger => sil.Trigger(trigger.exps.map(x => renaming(x)))(trigger.pos, trigger.info))
 
     //translate components
-    val (translatedCond, translatedArgs) = (expModule.translateExp(renamingCond), renamingArgs.map(expModule.translateExp))
+    val (translatedCond, translatedArgs) = (expModule.translateExpInWand(renamingCond), renamingArgs.map(expModule.translateExpInWand))
     val translatedLocals = vsFresh.map(v => mainModule.translateLocalVarDecl(v))
     // wildcard permissions are not supported inside package statements and are rejected
     // upfront via permModule.containsWildCard (see DefaultExhaleModule.exhaleConnective)

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -243,7 +243,7 @@ class QuantifiedPermModule(val verifier: Verifier)
       Func(minMasks, args, maskType) ++
         Axiom(Forall(
           args ++ Seq(obj, field),
-          Trigger(Seq(funcApp, permResult)),
+          Seq(Trigger(permResult), Trigger(Seq(funcApp, permSummand1)), Trigger(Seq(funcApp, permSummand2))),
           (permResult === CondExp(permSummand1 < permSummand2, permSummand1, permSummand2))
         ))
     } ++ {
@@ -308,6 +308,8 @@ class QuantifiedPermModule(val verifier: Verifier)
   }
 
   def staticGoodMask = FuncApp(goodMaskName, LocalVar(maskName, maskType), Bool)
+
+  def goodMask(msk: Exp): Exp = FuncApp(goodMaskName, msk, Bool)
 
   private def permAdd(a: Exp, b: Exp): Exp = a + b
   private def permSub(a: Exp, b: Exp): Exp = a - b
@@ -1508,12 +1510,9 @@ class QuantifiedPermModule(val verifier: Verifier)
     } else Nil
   }
 
-  override def hasSomePerm(mask: Exp, resource: Exp): Exp = {
+  override def hasSomePerm(mask: Exp, fieldType: Type): Exp = {
     val obj = LocalVarDecl(Identifier("o"), refType) // ref-typed variable, representing arbitrary receiver
-    val typ = resource match {
-      case FuncApp(_, _, t) => fieldTypeOf(t)
-    }
-    val field = LocalVarDecl(Identifier("f"), typ)
+    val field = LocalVarDecl(Identifier("f"), fieldType)
     val perm = currentPermission(mask, obj.l, field.l)
     Exists(Seq(obj, field), Trigger(perm), perm > noPerm)
   }

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -387,7 +387,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     FuncApp(sumMasks, resultMask++summandMask1++summandMask2,Bool)
 
   override def minMask(summandMask1: Seq[Exp], summandMask2: Seq[Exp]): Exp =
-    FuncApp(minMasks, summandMask1 ++ summandMask2, Bool)
+    FuncApp(minMasks, summandMask1 ++ summandMask2, maskType)
 
   override def containsWildCard(e: sil.Exp): Boolean = {
     e match {

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -368,6 +368,8 @@ class QuantifiedPermModule(val verifier: Verifier)
    */
   override def permissionPositive(permission: Exp, zeroOK : Boolean = false): Exp = permissionPositiveInternal(permission, None, zeroOK)
 
+  override def permissionZero(permission: Exp): Exp = permission === noPerm
+
   private def permissionPositiveInternal(permission: Exp, silPerm: Option[sil.Exp] = None, zeroOK : Boolean = false): Exp = {
     (permission, silPerm) match {
       case (x, _) if permission == fullPerm => TrueLit()
@@ -1510,11 +1512,11 @@ class QuantifiedPermModule(val verifier: Verifier)
     } else Nil
   }
 
-  override def hasSomePerm(mask: Exp, fieldType: Type): Exp = {
-    val obj = LocalVarDecl(Identifier("o"), refType) // ref-typed variable, representing arbitrary receiver
-    val field = LocalVarDecl(Identifier("f"), fieldType)
-    val perm = currentPermission(mask, obj.l, field.l)
-    Exists(Seq(obj, field), Trigger(perm), perm > noPerm)
+  override def hasSomePerm(mask: Exp, vars: Seq[LocalVarDecl], rcv: Exp, fld: Exp): Exp = {
+    //val obj = LocalVarDecl(Identifier("o"), refType) // ref-typed variable, representing arbitrary receiver
+    //val field = LocalVarDecl(Identifier("f"), fieldType)
+    val perm = currentPermission(mask, rcv, fld)
+    Exists(vars, Trigger(perm), perm > noPerm)
   }
 
   override def tempInitMask(rcv: Exp, loc:Exp):(Seq[Exp], Stmt) = {

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -41,7 +41,7 @@ import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.Implies
 
 import scala.collection.mutable.ListBuffer
-import viper.silver.ast.utility.QuantifiedPermissions.SourceQuantifiedPermissionAssertion
+import viper.silver.ast.utility.QuantifiedPermissions.{QuantifiedPermissionAssertion, SourceQuantifiedPermissionAssertion}
 import viper.silver.verifier.errors.{ContractNotWellformed, PostconditionViolated}
 
 /**
@@ -394,6 +394,8 @@ class QuantifiedPermModule(val verifier: Verifier)
       case sil.AccessPredicate(loc, prm) =>
         val p = PermissionHelper.normalizePerm(prm)
         p.isInstanceOf[sil.WildcardPerm]
+      case QuantifiedPermissionAssertion(_, _, acc: sil.AccessPredicate) =>
+        conservativeIsWildcardPermission(acc.perm)
       case _ => false
     }
   }


### PR DESCRIPTION
Carbon currently crashes when having to exhale a QP during a package operation, so when there is a QP on the right hand side of a wand or when one is asserted inside a ``package`` statement.
This is due to a missing implementation of ``exhaleExt``, which exhales permissions from a stack of heaps instead of a single one. This PR adds this implementation, which closely follows the one for the existing implementation for individual permissions (for example, there is now a method ``transferMainQuant`` with a similar structure as the existing ``transferMain`` method etc.)
Instead of a single variable tracking how many permissions are left to be exhaled, we track an entire *mask* that contains all permissions that are left to be exhaled.

Like the existing ``exhaleExt`` implementation for non-quantified permissions, wildcards are currently not supported (and Carbon fails in the same way). 