### PR TITLE
Enable fatal warnings and fix compiler warnings throughout codebase

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,9 @@ lazy val carbon = (project in file("."))
         organization := "viper",
         version := "1.0-SNAPSHOT",
 
+        // Compilation settings
+        scalacOptions += "-Xfatal-warnings",    // Treat warnings as errors to guarantee code quality in future changes
+
         // Fork test to a different JVM than SBT's, avoiding SBT's classpath interfering with
         // classpath used by Scala's reflection.
         Test / fork := true,

--- a/src/main/scala/viper/carbon/Carbon.scala
+++ b/src/main/scala/viper/carbon/Carbon.scala
@@ -21,7 +21,7 @@ object Carbon extends CarbonFrontend(StdIOReporter("carbon_reporter"), ViperStdO
     val submitter = new FileProgramSubmitter(this)
     submitter.setArgs(args)
 
-    execute(args)
+    execute(args.toIndexedSeq)
     specifyAppExitCode()
 
     submitter.submit()

--- a/src/main/scala/viper/carbon/boogie/BoogieModelTransformer.scala
+++ b/src/main/scala/viper/carbon/boogie/BoogieModelTransformer.scala
@@ -1,7 +1,7 @@
 package viper.carbon.boogie
 
 import viper.carbon.verifier.FailureContextImpl
-import viper.silver.verifier.{AbstractError, Counterexample, FailureContext, Model, ModelEntry, SimpleCounterexample, VerificationError}
+import viper.silver.verifier.{AbstractError, Model, ModelEntry, SimpleCounterexample, VerificationError}
 
 import scala.collection.mutable
 

--- a/src/main/scala/viper/carbon/boogie/Implicits.scala
+++ b/src/main/scala/viper/carbon/boogie/Implicits.scala
@@ -14,8 +14,8 @@ import language.implicitConversions
  */
 object Implicits {
   implicit def lift[T](t: T): Seq[T] = Seq(t)
-  implicit def liftStmt(ss: Seq[Stmt]) = Seqn(ss)
-  implicit def liftSeq(ss: Seq[Exp]) = new BoolSeq(ss)
+  implicit def liftStmt(ss: Seq[Stmt]): Seqn = Seqn(ss)
+  implicit def liftSeq(ss: Seq[Exp]): BoolSeq = new BoolSeq(ss)
 
   /**
    * Adds methods to turn a sequence of expressions into their conjunction or disjunction.

--- a/src/main/scala/viper/carbon/boogie/UnicodeString.scala
+++ b/src/main/scala/viper/carbon/boogie/UnicodeString.scala
@@ -21,5 +21,5 @@ class UnicodeString(val s: String) {
   }
 }
 object UnicodeString {
-  implicit def string2unicodestring(s: String) = new UnicodeString(s)
+  implicit def string2unicodestring(s: String): UnicodeString = new UnicodeString(s)
 }

--- a/src/main/scala/viper/carbon/boogie/boogie.scala
+++ b/src/main/scala/viper/carbon/boogie/boogie.scala
@@ -11,6 +11,7 @@ import viper.silver.ast.Member
 import viper.silver.ast.pretty._
 import viper.silver.verifier.VerificationError
 
+import scala.annotation.unused
 import scala.collection.mutable
 
 /** The root of the Boogie AST. */
@@ -48,7 +49,7 @@ sealed trait Node {
    * Applies the function `f1` to the AST node, then visits all subnodes,
    * and finally calls `f2` to the AST node.
    */
-  def visit(n: Node, f1: PartialFunction[Node, Unit], f2: PartialFunction[Node, Unit]): Unit = {
+  def visit(@unused n: Node, f1: PartialFunction[Node, Unit], f2: PartialFunction[Node, Unit]): Unit = {
     Visitor.visit(this, f1, f2)
   }
 
@@ -56,7 +57,7 @@ sealed trait Node {
    * Applies the function `f` to the AST node, then visits all subnodes if `f`
    * returned true.
    */
-  def visitOpt(n: Node)(f: Node => Boolean): Unit = {
+  def visitOpt(@unused n: Node)(f: Node => Boolean): Unit = {
     Visitor.visitOpt(this)(f)
   }
 
@@ -64,7 +65,7 @@ sealed trait Node {
    * Applies the function `f1` to the AST node, then visits all subnodes if `f1`
    * returned true, and finally calls `f2` to the AST node.
    */
-  def visitOpt(n: Node, f1: Node => Boolean, f2: Node => Unit): Unit = {
+  def visitOpt(@unused n: Node, f1: Node => Boolean, f2: Node => Unit): Unit = {
     Visitor.visitOpt(this, f1, f2)
   }
 

--- a/src/main/scala/viper/carbon/boogie/utility.scala
+++ b/src/main/scala/viper/carbon/boogie/utility.scala
@@ -154,13 +154,13 @@ object Nodes {
       case Some(ee) => ee
       case None =>
         exp match {
-          case IntLit(i) => exp
-          case BoolLit(b) => exp
-          case RealLit(b) => exp
+          case IntLit(_) => exp
+          case BoolLit(_) => exp
+          case RealLit(_) => exp
           case RealConv(exp) => RealConv(func(exp))
-          case LocalVar(n, tt) => exp
-          case GlobalVar(n, tt) => exp
-          case Const(i) => exp
+          case LocalVar(_, _) => exp
+          case GlobalVar(_, _) => exp
+          case Const(_) => exp
           case MapSelect(map, idxs) => MapSelect(func(map), idxs map func)
           case MapUpdate(map, idxs, value) => MapUpdate(func(map), idxs map func, func(value))
           case Old(e) => Old(func(e))

--- a/src/main/scala/viper/carbon/modules/ExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/ExhaleModule.scala
@@ -6,7 +6,7 @@
 
 package viper.carbon.modules
 
-import components.{ComponentRegistry, DefinednessState, ExhaleComponent}
+import components.{ComponentRegistry, ExhaleComponent}
 import viper.silver.{ast => sil}
 import viper.carbon.boogie.Stmt
 import viper.silver.verifier.PartialVerificationError

--- a/src/main/scala/viper/carbon/modules/HeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/HeapModule.scala
@@ -9,8 +9,6 @@ package viper.carbon.modules
 import viper.silver.{ast => sil}
 import viper.carbon.boogie._
 import viper.carbon.modules.components.CarbonStateComponent
-import viper.carbon.utility.PolyMapDesugarHelper
-import viper.silver.ast.{LocationAccess, MagicWand}
 
 /**
  * A module for translating heap expressions (access, updating) and determining

--- a/src/main/scala/viper/carbon/modules/Module.scala
+++ b/src/main/scala/viper/carbon/modules/Module.scala
@@ -59,5 +59,5 @@ trait Module extends LifetimeComponent with StatefulComponent with viper.carbon.
  * Trait to extend in modules which promise *not* to require a reset method
  */
 trait StatelessComponent {
-  final def reset = { }
+  final def reset(): Unit = { }
 }

--- a/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/DefinednessComponent.scala
@@ -10,6 +10,8 @@ import viper.carbon.boogie.{Statements, Stmt}
 import viper.silver.{ast => sil}
 import viper.silver.verifier.PartialVerificationError
 
+import scala.annotation.unused
+
 /**
  * Takes care of determining whether expressions are well-formed.
  */
@@ -18,7 +20,7 @@ trait DefinednessComponent extends Component {
   /**
    * Free assumptions about an expression.
    */
-  def freeAssumptions(e: sil.Exp): Stmt = Statements.EmptyStmt
+  def freeAssumptions(@unused e: sil.Exp): Stmt = Statements.EmptyStmt
 
   /**
     * Well-definedness check for `e` itself (not its subnodes). This check is invoked *before* invoking the
@@ -30,15 +32,17 @@ trait DefinednessComponent extends Component {
     * definedness check should be made, otherwise these checks should be done in the currently active state.
     * Expressions should be evaluated in the currently active state.
    */
-  def simplePartialCheckDefinednessBefore(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                                          definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
+  def simplePartialCheckDefinednessBefore(@unused e: sil.Exp, @unused error: PartialVerificationError,
+                                          @unused makeChecks: Boolean,
+                                          @unused definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
     * Same as [[simplePartialCheckDefinednessBefore]], except that this well-definedness check is invoked and emitted
     * *after* the well-definedness checks of `e`'s subnodes are invoked and emitted.
     */
-  def simplePartialCheckDefinednessAfter(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean,
-                                         definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
+  def simplePartialCheckDefinednessAfter(@unused e: sil.Exp, @unused error: PartialVerificationError,
+                                         @unused makeChecks: Boolean,
+                                         @unused definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
    * Proof obligations for a given expression.  The first part of the result is used before

--- a/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/ExhaleComponent.scala
@@ -10,6 +10,8 @@ import viper.carbon.boogie.{Statements, Stmt}
 import viper.silver.{ast => sil}
 import viper.silver.verifier.PartialVerificationError
 
+import scala.annotation.unused
+
 /**
  * Takes care of exhaling one or several kinds of expressions.
 
@@ -19,7 +21,8 @@ trait ExhaleComponent extends Component {
   /**
    * Exhale a single expression.
    */
-  def exhaleExp(e: sil.Exp, error: PartialVerificationError, definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
+  def exhaleExp(@unused e: sil.Exp, @unused error: PartialVerificationError,
+                @unused definednessStateOpt: Option[DefinednessState]): Stmt = Statements.EmptyStmt
 
   /**
     */

--- a/src/main/scala/viper/carbon/modules/components/StmtComponent.scala
+++ b/src/main/scala/viper/carbon/modules/components/StmtComponent.scala
@@ -10,6 +10,8 @@ import viper.silver.{ast => sil}
 import viper.carbon.boogie._
 import viper.silver.ast.LocalVar
 
+import scala.annotation.unused
+
 /**
  * Contributes to the translation of one or several statements.
  */
@@ -35,5 +37,5 @@ trait StmtComponent extends Component {
   /**
    * This method is called when translating a "fresh" statement, and by default does nothing
    */
-  def freshReads(fb: Seq[LocalVar]): Stmt = Statements.EmptyStmt
+  def freshReads(@unused fb: Seq[LocalVar]): Stmt = Statements.EmptyStmt
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultDomainModule.scala
@@ -25,7 +25,7 @@ class DefaultDomainModule(val verifier: Verifier) extends DomainModule with Stat
 
   def name = "Domain module"
 
-  implicit val namespace = verifier.freshNamespace("domain")
+  implicit val namespace: Namespace = verifier.freshNamespace("domain")
 
   // name for output identifier (to try to avoid clashes - should be improved for robustness (see issue #19)
   def outputName(domain: sil.Domain) : String = domain.name + "DomainType"

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExhaleModule.scala
@@ -23,14 +23,13 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
 
   import verifier._
   import expModule._
-  import permModule._
   import heapModule._
   import mainModule._
   import stateModule._
 
   def name = "Exhale module"
 
-  override def reset = { }
+  override def reset(): Unit = { }
 
   override def start(): Unit = {
     register(this)
@@ -111,7 +110,7 @@ class DefaultExhaleModule(val verifier: Verifier) extends ExhaleModule {
     *                  Access to the current state is needed during translation of an exhale during packaging a wand
    */
   private def exhaleConnective(e: sil.Exp, error: PartialVerificationError, definednessCheckData: DefinednessCheckData,
-                               havocHeap: Boolean = true, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false,
+                               havocHeap: Boolean, statesStackForPackageStmt: List[Any], insidePackageStmt: Boolean,
                                isAssert: Boolean, currentStateForPackage: StateRep): Stmt = {
 
     e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultExpModule.scala
@@ -13,8 +13,9 @@ import viper.carbon.verifier.Verifier
 import viper.silver.verifier.{PartialVerificationError, reasons}
 import viper.carbon.boogie.Implicits._
 import viper.carbon.modules.components.{DefinednessComponent, DefinednessState}
-import viper.silver.ast.{LocationAccess, MagicWand, PredicateAccess, Ref}
 import viper.silver.ast.utility.Expressions
+
+import scala.annotation.unused
 
 /**
  * The default implementation of [[viper.carbon.modules.ExpModule]].
@@ -480,7 +481,7 @@ class DefaultExpModule(val verifier: Verifier) extends ExpModule with Definednes
     * checks self-framedness of both sides of wand
     * GP: maybe should "MagicWandNotWellFormed" error
     */
-  private def checkDefinednessWand(e: sil.MagicWand, error: PartialVerificationError, makeChecks: Boolean): Stmt = {
+  private def checkDefinednessWand(e: sil.MagicWand, error: PartialVerificationError, @unused makeChecks: Boolean): Stmt = {
     val (initStmtLHS, curState): (Stmt, stateModule.StateSnapshot) = stateModule.freshEmptyState("WandDefLHS", true)
     val defStateLHS = stateModule.state
     val (initStmtRHS, _): (Stmt, stateModule.StateSnapshot) = stateModule.freshEmptyState("WandDefRHS", true)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -18,7 +18,6 @@ import viper.silver.ast.utility._
 import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, ExhaleComponent, InhaleComponent}
 import viper.silver.verifier.{NullPartialVerificationError, PartialVerificationError, errors}
 
-import scala.annotation.unused
 import scala.collection.mutable.ListBuffer
 import viper.silver.ast.utility.QuantifiedPermissions.QuantifiedPermissionAssertion
 import viper.silver.verifier.reasons.NonPositivePermission
@@ -54,8 +53,6 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
 
   private val assumeFunctionsAboveName = Identifier("AssumeFunctionsAbove")
   private val assumeFunctionsAbove: Const = Const(assumeFunctionsAboveName)
-  private val specialRefName = Identifier("special_ref")
-  @unused private val specialRef = Const(specialRefName)
 
   /* limitedPostfix is appended to the actual function name to get the name of the limited function.
    * It must be a string that cannot appear in Viper identifiers to ensure that we can easily check if a given identifier
@@ -601,7 +598,6 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
 
           val (_, curState) = stateModule.freshTempState("Heap2")
           val heap1 = heapModule.currentStateContributions
-          @unused val mask1 = permModule.currentStateContributions
 
 
 
@@ -617,7 +613,6 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           val (_, _) = stateModule.freshTempState("Heap1")
 
           val heap2 = heapModule.currentStateContributions
-          @unused val mask2 = permModule.currentStateContributions
 
           val locationAccess2 = translateResourceAccess(locationAccess)
           val translatedCond2 = translateExp(renamedCond)
@@ -1123,7 +1118,6 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           (before, after)
       }
       case sil.PredicateAccessPredicate(loc@sil.PredicateAccess(args, predicateName), _) if duringUnfold =>
-        @unused val oldVersion = LocalVar(Identifier("oldVersion"), predicateVersionType)
         val newVersion = LocalVar(Identifier("newVersion"), predicateVersionType)
         val stmt: Stmt = if (exhaleTmpStateId >= 0 || duringUnfolding) Nil else //(oldVersion := curVersion) ++
            Havoc(Seq(newVersion)) ++

--- a/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultFuncPredModule.scala
@@ -18,6 +18,7 @@ import viper.silver.ast.utility._
 import viper.carbon.modules.components.{DefinednessComponent, DefinednessState, ExhaleComponent, InhaleComponent}
 import viper.silver.verifier.{NullPartialVerificationError, PartialVerificationError, errors}
 
+import scala.annotation.unused
 import scala.collection.mutable.ListBuffer
 import viper.silver.ast.utility.QuantifiedPermissions.QuantifiedPermissionAssertion
 import viper.silver.verifier.reasons.NonPositivePermission
@@ -41,7 +42,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   import heapModule._
   import permModule._
 
-  implicit val fpNamespace = verifier.freshNamespace("funcpred")
+  implicit val fpNamespace: Namespace = verifier.freshNamespace("funcpred")
 
   /* Maps function names to their height.
    * Previously mapped Function AST nodes to their height, but this prevents looking up functions
@@ -54,7 +55,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   private val assumeFunctionsAboveName = Identifier("AssumeFunctionsAbove")
   private val assumeFunctionsAbove: Const = Const(assumeFunctionsAboveName)
   private val specialRefName = Identifier("special_ref")
-  private val specialRef = Const(specialRefName)
+  @unused private val specialRef = Const(specialRefName)
 
   /* limitedPostfix is appended to the actual function name to get the name of the limited function.
    * It must be a string that cannot appear in Viper identifiers to ensure that we can easily check if a given identifier
@@ -321,7 +322,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
          pacc.args.forall(arg => !arg.existsDefined[Unit]({case v:sil.LocalVar if !silArgsLocalVar.contains(v) => }  ))
 
       outerUnfoldings.flatMap {
-        case Unfolding(PredicateAccessPredicate(predacc: PredicateAccess, perm), exp)
+        case Unfolding(PredicateAccessPredicate(predacc: PredicateAccess, _), _)
           if hasOnlyDefinedVars(predacc) => Some(predicateTrigger(heap map (_.l), predacc))
         case _ => None}.flatten
     }
@@ -345,7 +346,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
    * Transform all function applications to their limited form (or form used in triggers, if the "triggerForm" Boolean is passed as true.
    * If height is provided (i.e., non-negative), functions of above that height need not have their applications replaced with the limited form.
    */
-  private def transformFuncAppsToLimitedOrTriggerForm(exp: Exp, heightToSkip : Int = -1, triggerForm: Boolean = false): Exp = {
+  private def transformFuncAppsToLimitedOrTriggerForm(exp: Exp, heightToSkip : Int, triggerForm: Boolean): Exp = {
     def transformer: PartialFunction[Exp, Option[Exp]] = {
       case FuncApp(recf, recargs, t) if recf.namespace == fpNamespace &&
         // recf might refer to a limited function already if the function was marked as opaque.
@@ -447,7 +448,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
       pacc.args.forall(arg => !arg.existsDefined[Unit]({case v:sil.LocalVar if !silArgsLocalVar.contains(v) => }  ))
 
     val predicateTriggers : Seq[Exp] = outerUnfoldings.flatMap {
-      case Unfolding(PredicateAccessPredicate(predacc: PredicateAccess, perm), exp)
+      case Unfolding(PredicateAccessPredicate(predacc: PredicateAccess, _), _)
         if hasOnlyDefinedVars(predacc) => Some(predicateTrigger(heap map (_.l), predacc))
       case _ => None}.flatten
 
@@ -554,7 +555,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
     def frameFragment(e: Exp) = {
       FuncApp(frameFragmentName, Seq(e), frameType)
     }
-    assertion match {
+    (assertion: @unchecked) match {
       case s@sil.AccessPredicate(la, perm) =>
         val fragmentBody = translateResourceAccess(renaming(la).asInstanceOf[sil.LocationAccess])
         val fragment = if (s.isInstanceOf[PredicateAccessPredicate]) fragmentBody else frameFragment(fragmentBody)
@@ -600,7 +601,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
 
           val (_, curState) = stateModule.freshTempState("Heap2")
           val heap1 = heapModule.currentStateContributions
-          val mask1 = permModule.currentStateContributions
+          @unused val mask1 = permModule.currentStateContributions
 
 
 
@@ -616,7 +617,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
           val (_, _) = stateModule.freshTempState("Heap1")
 
           val heap2 = heapModule.currentStateContributions
-          val mask2 = permModule.currentStateContributions
+          @unused val mask2 = permModule.currentStateContributions
 
           val locationAccess2 = translateResourceAccess(locationAccess)
           val translatedCond2 = translateExp(renamedCond)
@@ -985,7 +986,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
 
   override def translateFold(fold: sil.Fold, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): (Stmt,Stmt) = {
     fold match {
-      case sil.Fold(acc@sil.PredicateAccessPredicate(pa@sil.PredicateAccess(_, _), perm)) => {
+      case sil.Fold(acc@sil.PredicateAccessPredicate(sil.PredicateAccess(_, _), perm)) => {
         {
           val (foldFirst, foldLast) = foldPredicate(acc, errors.FoldFailed(fold), statesStackForPackageStmt, insidePackageStmt)
           if(insidePackageStmt){
@@ -1005,7 +1006,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   private var duringFold = false
   private var foldInfo: sil.PredicateAccessPredicate = null
   private def foldPredicate(acc: sil.PredicateAccessPredicate, error: PartialVerificationError
-                           , statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): (Stmt,Stmt) = {
+                           , statesStackForPackageStmt: List[Any], insidePackageStmt: Boolean): (Stmt,Stmt) = {
     duringFold = true
     foldInfo = acc
     val stmt = Assert(permModule.isStrictlyPositivePerm(acc.perm), error.dueTo(NonPositivePermission(acc.perm))) ++
@@ -1030,7 +1031,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
   private var unfoldInfo: sil.PredicateAccessPredicate = null
   override def translateUnfold(unfold: sil.Unfold, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt = {
     unfold match {
-      case sil.Unfold(acc@sil.PredicateAccessPredicate(pa@sil.PredicateAccess(_, _), perm)) =>
+      case sil.Unfold(acc@sil.PredicateAccessPredicate(sil.PredicateAccess(_, _), perm)) =>
         checkDefinedness(acc, errors.UnfoldFailed(unfold), insidePackageStmt = insidePackageStmt) ++
           // If no permission amount is supplied explicitly, we always use the default FullPerm; this is
           // okay even if we are inside a function and only want to check for some positive amount, because permission
@@ -1121,8 +1122,8 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
 
           (before, after)
       }
-      case pap@sil.PredicateAccessPredicate(loc@sil.PredicateAccess(args, predicateName), _) if duringUnfold =>
-        val oldVersion = LocalVar(Identifier("oldVersion"), predicateVersionType)
+      case sil.PredicateAccessPredicate(loc@sil.PredicateAccess(args, predicateName), _) if duringUnfold =>
+        @unused val oldVersion = LocalVar(Identifier("oldVersion"), predicateVersionType)
         val newVersion = LocalVar(Identifier("newVersion"), predicateVersionType)
         val stmt: Stmt = if (exhaleTmpStateId >= 0 || duringUnfolding) Nil else //(oldVersion := curVersion) ++
            Havoc(Seq(newVersion)) ++
@@ -1168,7 +1169,7 @@ with DefinednessComponent with ExhaleComponent with InhaleComponent {
         CommentBlock("Execute unfolding (for extra information)",stmts)
       }
 
-      case pap@sil.PredicateAccessPredicate(loc@sil.PredicateAccess(_, _), perm) =>
+      case pap@sil.PredicateAccessPredicate(loc@sil.PredicateAccess(_, _), _) =>
         val res: Stmt = if (extraUnfolding) {
           exhaleTmpStateId += 1
           extraUnfolding = false

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -79,8 +79,6 @@ class DefaultHeapModule(val verifier: Verifier)
   private val exhaleHeapName = Identifier("ExhaleHeap")
   private val exhaleHeap = LocalVar(exhaleHeapName, heapTyp)
   private val originalHeap = GlobalVar(heapName, heapTyp)
-  private val qpHeapName = Identifier("QPHeap")
-  @unused private val qpHeap = LocalVar(qpHeapName, heapTyp)
   private var heap: Var = originalHeap
   private def heapVar: Var = {assert (!usingOldState); heap}
   private def heapExp: Exp = if (usingPureState) dummyHeap else heap

--- a/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultHeapModule.scala
@@ -7,7 +7,7 @@
 package viper.carbon.modules.impls
 
 import viper.carbon.modules._
-import viper.carbon.modules.components.{DefinednessComponent, InhaleComponent, SimpleStmtComponent}
+import viper.carbon.modules.components.{DefinednessComponent, SimpleStmtComponent}
 import viper.silver.ast.utility.Expressions
 import viper.silver.{ast => sil}
 import viper.carbon.boogie._
@@ -15,7 +15,8 @@ import viper.carbon.boogie.Implicits._
 import viper.carbon.verifier.Verifier
 import viper.carbon.utility.{PolyMapDesugarHelper, PolyMapRep}
 import viper.silver.ast.utility.QuantifiedPermissions.QuantifiedPermissionAssertion
-import viper.silver.verifier.PartialVerificationError
+
+import scala.annotation.unused
 
 /**
  * The default implementation of a [[viper.carbon.modules.HeapModule]].
@@ -33,7 +34,7 @@ class DefaultHeapModule(val verifier: Verifier)
   import mainModule._
 
   def name = "Heap module"
-  implicit val heapNamespace = verifier.freshNamespace("heap")
+  implicit val heapNamespace: Namespace = verifier.freshNamespace("heap")
   val fieldNamespace = verifier.freshNamespace("heap.fields")
   // a fresh namespace for every axiom
   def axiomNamespace = verifier.freshNamespace("heap.axiom")
@@ -79,7 +80,7 @@ class DefaultHeapModule(val verifier: Verifier)
   private val exhaleHeap = LocalVar(exhaleHeapName, heapTyp)
   private val originalHeap = GlobalVar(heapName, heapTyp)
   private val qpHeapName = Identifier("QPHeap")
-  private val qpHeap = LocalVar(qpHeapName, heapTyp)
+  @unused private val qpHeap = LocalVar(qpHeapName, heapTyp)
   private var heap: Var = originalHeap
   private def heapVar: Var = {assert (!usingOldState); heap}
   private def heapExp: Exp = if (usingPureState) dummyHeap else heap
@@ -109,12 +110,12 @@ class DefaultHeapModule(val verifier: Verifier)
 
   override def preamble = {
     val obj = LocalVarDecl(Identifier("o")(axiomNamespace), refType)
-    val obj2 = LocalVarDecl(Identifier("o2")(axiomNamespace), refType)
+    @unused val obj2 = LocalVarDecl(Identifier("o2")(axiomNamespace), refType)
     val refField = LocalVarDecl(Identifier("f")(axiomNamespace), fieldTypeOf(refType))
     val obj_refField = lookup(LocalVar(heapName, heapTyp), obj.l, refField.l)
     val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
-    val field2 = LocalVarDecl(Identifier("f2")(axiomNamespace), NamedType(fieldTypeName, Seq(TypeVar("A2"), TypeVar("B2"))))
-    val predField = LocalVarDecl(Identifier("pm_f")(axiomNamespace),
+    @unused val field2 = LocalVarDecl(Identifier("f2")(axiomNamespace), NamedType(fieldTypeName, Seq(TypeVar("A2"), TypeVar("B2"))))
+    @unused val predField = LocalVarDecl(Identifier("pm_f")(axiomNamespace),
       predicateVersionFieldType("C"))
     val useSumOfStatesAxioms = loopModule.sumOfStatesAxiomRequired
 
@@ -467,7 +468,7 @@ class DefaultHeapModule(val verifier: Verifier)
           val varDecls2 = varDecls map (
             v => LocalVarDecl(Identifier(v.name.name + "2")(v.name.namespace), v.typ))
           val vars2 = varDecls2 map (_.l)
-          var varsEqual = All((vars zip vars2) map {
+          val varsEqual = All((vars zip vars2) map {
             case (v1, v2) => v1 === v2
           })
           val f0_2 = FuncApp(predicate, vars2, t)
@@ -566,7 +567,7 @@ class DefaultHeapModule(val verifier: Verifier)
     f match {
       case sil.FieldAccess(rcv, _) => (translateExp(rcv), translateResource(f))
       case sil.PredicateAccess(_, _) => (nullLit, translateResource(f))
-      case w: sil.MagicWand => (nullLit, translateResource(f))
+      case _: sil.MagicWand => (nullLit, translateResource(f))
     }
 
   override def currentHeapAssignUpdate(f: sil.LocationAccess, newVal: Exp): Stmt = {
@@ -578,7 +579,7 @@ class DefaultHeapModule(val verifier: Verifier)
     heap := heapUpdate(heap, rcv, field, newVal)
   }
 
-  private def heapUpdateLoc(heap: Exp, f: sil.LocationAccess, newVal: Exp, isPMask: Boolean = false): Exp = {
+  private def heapUpdateLoc(heap: Exp, f: sil.LocationAccess, newVal: Exp, isPMask: Boolean): Exp = {
     val (rcvExp, fieldExp) = rcvAndFieldExp(f)
     heapUpdate(heap, rcvExp, fieldExp, newVal, isPMask)
   }
@@ -630,7 +631,7 @@ class DefaultHeapModule(val verifier: Verifier)
               t =>
                 Assume(validReference(t))
             })
-          case sil.Fold(sil.PredicateAccessPredicate(loc, perm)) => // AS: this should really be taken care of in the FuncPredModule (and factored out to share code with unfolding case, if possible)
+          case sil.Fold(sil.PredicateAccessPredicate(loc, _)) => // AS: this should really be taken care of in the FuncPredModule (and factored out to share code with unfolding case, if possible)
             if(usingOldState) sys.error("heap module: fold is executed while using old state")
             stmt ++ ({val newVersion = LocalVar(Identifier("freshVersion"), funcPredModule.predicateVersionType)
               val resetPredicateInfo : Stmt =
@@ -677,9 +678,9 @@ class DefaultHeapModule(val verifier: Verifier)
   override def addPermissionToWMask(wMaskField: Exp, e: sil.Exp): Stmt = {
     if(usingOldState) { sys.error("Updating wand mask while using old state") }
     e match {
-      case sil.FieldAccessPredicate(loc, perm) =>
+      case sil.FieldAccessPredicate(loc, _) =>
         curHeapAssignUpdatePredWandMask(wMaskField, heapUpdateLoc(wandMask(wMaskField), loc, TrueLit(), true))
-      case sil.PredicateAccessPredicate(loc, perm) =>
+      case sil.PredicateAccessPredicate(loc, _) =>
         val newPMask = LocalVar(Identifier("newPMask"), pmaskType)
         val obj = LocalVarDecl(Identifier("o")(axiomNamespace), refType)
         val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
@@ -733,9 +734,9 @@ class DefaultHeapModule(val verifier: Verifier)
             curHeapAssignUpdatePredWandMask(pmask.maskField, newPMask)
         vsFresh.foreach(vFresh => env.undefine(vFresh.localVar))
         res
-      case sil.FieldAccessPredicate(loc, perm) =>
+      case sil.FieldAccessPredicate(loc, _) =>
         curHeapAssignUpdatePredWandMask(pmask.maskField, heapUpdateLoc(pmask.mask, loc, TrueLit(), true))
-      case sil.PredicateAccessPredicate(loc, perm) =>
+      case sil.PredicateAccessPredicate(loc, _) =>
         val newPMask = LocalVar(Identifier("newPMask"), pmaskType)
         val obj = LocalVarDecl(Identifier("o")(axiomNamespace), refType)
         val field = LocalVarDecl(Identifier("f")(axiomNamespace), fieldType)
@@ -815,7 +816,7 @@ class DefaultHeapModule(val verifier: Verifier)
    * Reset the state of this module so that it can be used for new program. This method is called
    * after verifier gets a new program.
    */
-  override def reset = {
+  override def reset(): Unit = {
     PredIdMap = Map()
     NextPredicateId = 0
     heap = originalHeap

--- a/src/main/scala/viper/carbon/modules/impls/DefaultInhaleModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultInhaleModule.scala
@@ -63,7 +63,7 @@ class DefaultInhaleModule(val verifier: Verifier) extends InhaleModule with Stat
    * Inhales Viper expression connectives (such as logical and/or) and forwards the
    * translation of other expressions to the inhale components.
    */
-  private def inhaleConnective(e: sil.Exp, error: PartialVerificationError, addDefinednessChecks: Boolean, statesStackForPackageStmt: List[Any] = null, insidePackageStmt: Boolean = false): Stmt = {
+  private def inhaleConnective(e: sil.Exp, error: PartialVerificationError, addDefinednessChecks: Boolean, statesStackForPackageStmt: List[Any], insidePackageStmt: Boolean): Stmt = {
 
     def maybeDefCheck(eDef: sil.Exp) : Stmt = { if(addDefinednessChecks) checkDefinedness(eDef, error, insidePackageStmt = insidePackageStmt) else Statements.EmptyStmt }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -322,7 +322,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     def updateInvariantMap(info: sil.Info, invs: Seq[sil.Exp]): Unit = {
       info.getUniqueInfo[LoopInfo] match {
         case Some(LoopInfo(Some(headId), _)) =>
-          loopToInvs = loopToInvs.clone().addOne((headId, invs))
+          loopToInvs.update(headId, invs)
         case _ =>
       }
     }
@@ -330,7 +330,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     def updateLabelMap(labelName: String, info: sil.Info) = {
       info.getUniqueInfo[LoopInfo] match {
         case Some(loopInfo: LoopInfo) =>
-          labelLoopInfoMap = labelLoopInfoMap.clone().addOne((labelName, loopInfo))
+          labelLoopInfoMap.update(labelName, loopInfo)
         case None =>
       }
     }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -55,7 +55,6 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
   private val sumHeapName : Identifier = Identifier("LoopSumHeap")(namespace)
   private val sumHeap = LocalVar(sumHeapName, heapType)
 
-  @unused private var currentMethodIsAbstract = false;
   private var usedLoopDetectorOnce = false;
   private var useLoopDetector = false;
 
@@ -283,7 +282,6 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     val result =
       m.body match {
         case Some(s) =>
-          currentMethodIsAbstract = false
           val normalizedBody =
             s.transform(
               rewriteDummyStatements, sil.utility.rewriter.Traverse.BottomUp
@@ -296,7 +294,6 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
           captureRelevantNextStmts(loopInfoBody, Seq())
           m.copy(body = Some(loopInfoBody))(m.pos, m.info, m.errT)
         case None =>
-          currentMethodIsAbstract = true
           m
       }
 

--- a/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultLoopModule.scala
@@ -7,11 +7,11 @@ import viper.carbon.verifier.Verifier
 import Implicits._
 import viper.carbon.modules.components.StmtComponent
 import viper.carbon.utility._
-import viper.silver.ast.utility.ViperStrategy
 import viper.silver.cfg.utility.{IdInfo, LoopDetector, LoopInfo}
 import viper.silver.reporter.WarningsDuringVerification
 import viper.silver.verifier.{PartialVerificationError, VerifierWarning, errors}
 
+import scala.annotation.unused
 import scala.collection.mutable
 import scala.collection.mutable.Map
 import scala.collection.immutable.{Map => ImmutableMap}
@@ -37,7 +37,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
   import permModule._
   import heapModule._
 
-  implicit val namespace = verifier.freshNamespace("loop")
+  implicit val namespace: Namespace = verifier.freshNamespace("loop")
 
   //separate masks for each loop to store the permissions which are framed away
   private var frames: Map[Int, (LocalVarDecl,LocalVarDecl)] = Map[Int, (LocalVarDecl, LocalVarDecl)]();
@@ -55,7 +55,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
   private val sumHeapName : Identifier = Identifier("LoopSumHeap")(namespace)
   private val sumHeap = LocalVar(sumHeapName, heapType)
 
-  private var currentMethodIsAbstract = false;
+  @unused private var currentMethodIsAbstract = false;
   private var usedLoopDetectorOnce = false;
   private var useLoopDetector = false;
 
@@ -306,11 +306,11 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
   override def isLoopDummyStmt(stmt: sil.Stmt): Boolean =
     stmt.info.getUniqueInfo[LoopDummyStmtInfo].nonEmpty
 
-  override def sumOfStatesAxiomRequired(): Boolean = usedLoopDetectorOnce
+  override def sumOfStatesAxiomRequired: Boolean = usedLoopDetectorOnce
 
   private def relevantForLoops(s: sil.Stmt) : Boolean = {
     s match {
-      case node@(_: sil.If | _: sil.Seqn) => false
+      case _: sil.If | _: sil.Seqn => false
       case _ => true
     }
   }
@@ -325,7 +325,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     def updateInvariantMap(info: sil.Info, invs: Seq[sil.Exp]): Unit = {
       info.getUniqueInfo[LoopInfo] match {
         case Some(LoopInfo(Some(headId), _)) =>
-          loopToInvs = loopToInvs + (headId -> invs)
+          loopToInvs = loopToInvs.clone().addOne((headId, invs))
         case _ =>
       }
     }
@@ -333,7 +333,7 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     def updateLabelMap(labelName: String, info: sil.Info) = {
       info.getUniqueInfo[LoopInfo] match {
         case Some(loopInfo: LoopInfo) =>
-          labelLoopInfoMap = labelLoopInfoMap + (labelName -> loopInfo)
+          labelLoopInfoMap = labelLoopInfoMap.clone().addOne((labelName, loopInfo))
         case None =>
       }
     }
@@ -488,7 +488,8 @@ class DefaultLoopModule(val verifier: Verifier) extends LoopModule with StmtComp
     }
   }
 
-  private def handleStmtLoopDetector(s: sil.Stmt, statesStackOfPackageStmt: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false): (Seqn => Seqn) = {
+  private def handleStmtLoopDetector(s: sil.Stmt, @unused statesStackOfPackageStmt: List[Any], @unused allStateAssms: Exp,
+                                     @unused insidePackageStmt: Boolean): (Seqn => Seqn) = {
     inner => {
       if (relevantForLoops(s)) {
         val stmtId = s.info.getUniqueInfo[IdInfo]

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMainModule.scala
@@ -38,12 +38,11 @@ class DefaultMainModule(val verifier: Verifier) extends MainModule with Stateles
   import heapModule._
   import funcPredModule._
   import domainModule._
-  import expModule._
 
   def name = "Main module"
 
   override val silVarNamespace = verifier.freshNamespace("main.silver")
-  implicit val mainNamespace = verifier.freshNamespace("main")
+  implicit val mainNamespace: Namespace = verifier.freshNamespace("main")
 
   override def translateLocalVarSig(typ:sil.Type, v:sil.LocalVar): LocalVarDecl = {
     val t: Type = translateType(typ)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultMapModule.scala
@@ -23,7 +23,7 @@ class DefaultMapModule(val verifier: Verifier) extends MapModule with Definednes
   /** The name of this module. */
   override def name: String = "Map module"
 
-  implicit val namespace = verifier.freshNamespace("map")
+  implicit val namespace: Namespace = verifier.freshNamespace("map")
 
   /** Have maps been used so far (to determine if we need to include the set axiomatisation in the prelude). */
   private var used = false

--- a/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultSeqModule.scala
@@ -34,7 +34,7 @@ class DefaultSeqModule(val verifier: Verifier)
   private var used = false
 
   def name = "Sequence module"
-  implicit val namespace = verifier.freshNamespace("seq")
+  implicit val namespace: Namespace = verifier.freshNamespace("seq")
 
   override def preamble = {
     if (used) {
@@ -62,7 +62,7 @@ class DefaultSeqModule(val verifier: Verifier)
           case Nil => sys.error("did not expect empty sequence")
           case a :: Nil =>
             FuncApp(Identifier("Seq#Singleton"), t(a), typ)
-          case a :: as =>
+          case _ :: _ =>
             translateSeqExp(s.desugared) // desugar into appends and singletons
         }
       case sil.RangeSeq(low, high) =>
@@ -77,7 +77,7 @@ class DefaultSeqModule(val verifier: Verifier)
         FuncApp(Identifier("Seq#Drop"), List(t(seq), t(n)), typ)
       case sil.SeqContains(elem, seq) =>
         FuncApp(Identifier("Seq#Contains"), List(t(seq), t(elem)), typ)
-      case sexp@sil.SeqUpdate(seq, idx, elem) =>
+      case sexp@sil.SeqUpdate(_, _, _) =>
       {
         // translate as (s[..i] ++ ([i] ++ s[i+1..])) (NOTE: this assumes i is in the range, which is not yet checked)
         t(sexp.desugaredAssumingIndexInRange)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultSetModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultSetModule.scala
@@ -32,7 +32,7 @@ class DefaultSetModule(val verifier: Verifier)
   private var used = false
 
   def name = "Set module"
-  implicit val namespace = verifier.freshNamespace("set")
+  implicit val namespace: Namespace = verifier.freshNamespace("set")
 
   //override def freeAssumptions(e: sil.Exp): Stmt = {
   //  e match {

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -12,6 +12,7 @@ import viper.carbon.boogie._
 import viper.carbon.boogie.Implicits._
 import viper.carbon.modules.components.CarbonStateComponent
 
+import scala.annotation.unused
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -25,7 +26,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
   private val isGoodState = "state"
 
-  implicit val stateNamespace = verifier.freshNamespace("state")
+  implicit val stateNamespace: Namespace = verifier.freshNamespace("state")
 
   override def assumeGoodState = {
     Assume(currentGoodState)
@@ -48,7 +49,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
     }
   }
 
-  override def reset : Unit = {
+  override def reset(): Unit = {
     curOldState = null
     curState = null
     //usingOldState = false
@@ -220,7 +221,7 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
   override def getCopyState:StateSnapshot = {
     val currentCopy = new StateComponentMapping()
-    val s = for (c <- components) yield {
+    @unused val s = for (c <- components) yield {
                 currentCopy.put(c, c.currentStateVars)
             }
     (currentCopy, usingOldState, usingPureState)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStateModule.scala
@@ -12,7 +12,6 @@ import viper.carbon.boogie._
 import viper.carbon.boogie.Implicits._
 import viper.carbon.modules.components.CarbonStateComponent
 
-import scala.annotation.unused
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -221,9 +220,9 @@ class DefaultStateModule(val verifier: Verifier) extends StateModule {
 
   override def getCopyState:StateSnapshot = {
     val currentCopy = new StateComponentMapping()
-    @unused val s = for (c <- components) yield {
-                currentCopy.put(c, c.currentStateVars)
-            }
+    for (c <- components) {
+      currentCopy.put(c, c.currentStateVars)
+    }
     (currentCopy, usingOldState, usingPureState)
   }
 }

--- a/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultStmtModule.scala
@@ -127,8 +127,8 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case assign@sil.FieldAssign(lhs, rhs) =>
         checkDefinedness(lhs.rcv, errors.AssignmentFailed(assign)) ++
           checkDefinedness(rhs, errors.AssignmentFailed(assign))
-      case fold@sil.Fold(e) => sys.error("Internal error: translation of fold statement cannot be handled by simpleHandleStmt code; found:" + fold.toString())
-      case unfold@sil.Unfold(e) =>
+      case fold@sil.Fold(_) => sys.error("Internal error: translation of fold statement cannot be handled by simpleHandleStmt code; found:" + fold.toString())
+      case unfold@sil.Unfold(_) =>
         translateUnfold(unfold, statesStack, insidePackageStmt)
       case inh@sil.Inhale(e) =>
         inhaleWithDefinednessCheck(whenInhaling(e), errors.InhaleFailed(inh), statesStack, insidePackageStmt)
@@ -192,7 +192,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
           (targets map (e => checkDefinedness(e, errors.CallFailed(mc), insidePackageStmt = insidePackageStmt))) ++
           (args map (e => checkDefinedness(e, errors.CallFailed(mc), insidePackageStmt = insidePackageStmt))) ++
           (actualArgs map (_._2)) ++
-          MaybeCommentBlock("Exhaling precondition", executeUnfoldings(pres, (pre => errors.PreconditionInCallFalse(mc).withReasonNodeTransformed(renamingArguments))) ++
+          MaybeCommentBlock("Exhaling precondition", executeUnfoldings(pres, (_ => errors.PreconditionInCallFalse(mc).withReasonNodeTransformed(renamingArguments))) ++
             exhaleWithoutDefinedness(pres map (e => (e, errors.PreconditionInCallFalse(mc).withReasonNodeTransformed(renamingArguments))), statesStackForPackageStmt = statesStack, insidePackageStmt = insidePackageStmt)) ++
           MaybeCommentBlock("Havocing target variables", Havoc((targets map translateExp).asInstanceOf[Seq[Var]])) ++
           {
@@ -208,7 +208,7 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case sil.While(_, _, _) =>
         //handled by LoopModule
         Nil
-      case i@sil.If(cond, thn, els) =>
+      case sil.If(cond, thn, els) =>
         val condTr = if(allStateAssms == TrueLit()) { translateExpInWand(cond) } else { allStateAssms ==> translateExpInWand(cond) }
         val condTempVar = LocalVar(Identifier("condition")(tmpVarsNamespace), Bool)
         checkDefinedness(cond, errors.IfFailed(cond), insidePackageStmt = insidePackageStmt) ++
@@ -231,11 +231,11 @@ class DefaultStmtModule(val verifier: Verifier) extends StmtModule with SimpleSt
       case sil.Goto(_) =>
         /* Handled by loop module, since the loop module decides whether the goto should be translated as a goto. */
         Nil
-      case pa@sil.Package(wand, proof) => {
+      case pa@sil.Package(wand, _) => {
         checkDefinedness(wand, errors.MagicWandNotWellformed(wand), insidePackageStmt = insidePackageStmt)
         translatePackage(pa, errors.PackageFailed(pa), statesStack, allStateAssms, insidePackageStmt)
       }
-      case a@sil.Apply(wand) =>
+      case a@sil.Apply(_) =>
         translateApply(a, errors.ApplyFailed(a), statesStack, allStateAssms, insidePackageStmt)
       case _ =>
         Nil

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -17,6 +17,8 @@ import viper.silver.ast.{MagicWand, MagicWandStructure}
 import viper.silver.verifier.{PartialVerificationError, reasons}
 import viper.silver.{ast => sil}
 
+import scala.annotation.unused
+
 class
 DefaultWandModule(val verifier: Verifier) extends WandModule with StmtComponent with DefinednessComponent{
   import verifier._
@@ -210,7 +212,7 @@ DefaultWandModule(val verifier: Verifier) extends WandModule with StmtComponent 
     val StateSetup(usedState, initStmt) = createAndSetState(boolVar, "Used", false).asInstanceOf[StateSetup]
 
     //inhale left hand side to initialize hypothetical state
-    val hypName = names.createUniqueIdentifier("Ops")
+    @unused val hypName = names.createUniqueIdentifier("Ops")
     val StateSetup(hypState,hypStmt) = createAndSetState(None,"Ops")
     OPS = hypState
     UNIONState = OPS
@@ -231,11 +233,11 @@ DefaultWandModule(val verifier: Verifier) extends WandModule with StmtComponent 
   override def translatePackage(p: sil.Package, error: PartialVerificationError, statesStack: List[Any] = null, allStateAssms: Exp = TrueLit(), inWand: Boolean = false):Stmt = {
     val proofScript = p.proofScript
     p match {
-      case pa@sil.Package(wand, proof) =>
+      case sil.Package(wand, _) =>
         wand match {
           case w@sil.MagicWand(left,right) =>
             // saving the old variables as they would be overwritten in the case of nested magic wands
-            var oldW = currentWand
+            val oldW = currentWand
             val oldOps = OPS
 
             currentWand = w
@@ -353,7 +355,7 @@ override def exhaleExt(statesObj: List[Any], usedObj:Any, e: sil.Exp, allStateAs
   }
 }
 
-def exhaleExtExp(states: List[StateRep], used:StateRep, e: sil.Exp,allStateAssms:Exp, RHS: Boolean = false, mainError: PartialVerificationError):Stmt = {
+def exhaleExtExp(@unused states: List[StateRep], used:StateRep, e: sil.Exp,allStateAssms:Exp, @unused RHS: Boolean = false, mainError: PartialVerificationError):Stmt = {
   if(e.isPure) {
     If(allStateAssms&&used.boolVar,expModule.checkDefinedness(e,mainError, insidePackageStmt = true),Statements.EmptyStmt) ++
       Assert((allStateAssms&&used.boolVar) ==> expModule.translateExpInWand(e), mainError.dueTo(reasons.AssertionFalse(e)))
@@ -371,7 +373,7 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
   val permAmount =
     e   match {
       case sil.MagicWand(left, right) => boogieFullPerm
-      case p@sil.AccessPredicate(loc, perm) => permModule.translatePerm(perm)
+      case sil.AccessPredicate(_, perm) => permModule.translatePerm(perm)
       case _ => sys.error("only transfer of access predicates and magic wands supported")
     }
 
@@ -398,7 +400,7 @@ def transferMain(states: List[StateRep], used:StateRep, e: sil.Exp, allStateAssm
 /*
  * Precondition: current state is set to the used state
   */
-private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEntity, allStateAssms: Exp, mainError: PartialVerificationError, havocHeap: Boolean = true):Stmt = {
+private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEntity, allStateAssms: Exp, mainError: PartialVerificationError, havocHeap: Boolean):Stmt = {
   states match {
     case (top :: xs) =>
       //Compute all values needed from top state
@@ -416,7 +418,7 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
       val minStmt = If(neededLocal <= curpermLocal,
         transferAmountLocal := neededLocal, transferAmountLocal := curpermLocal)
 
-      val nofractionsStmt = (transferAmountLocal := RealLit(1.0))
+      @unused val nofractionsStmt = (transferAmountLocal := RealLit(1.0))
 
       val curPermTop = permModule.currentPermission(e.rcv, e.loc)
       val removeFromTop = heapModule.beginExhale ++
@@ -579,7 +581,7 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
  *         in the Boogie program before the any translation concerning the TransferableEntity can be used
  */
 private def setupTransferableEntity(e: sil.Exp, permTransfer: Exp):(TransferableEntity,Stmt) = {
-  e match {
+  (e: @unchecked) match {
     case fa@sil.FieldAccessPredicate(loc, _) =>
       val assignStmt = rcvLocal := expModule.translateExpInWand(loc.rcv)
       val evalLoc = heapModule.translateResource(loc)
@@ -703,12 +705,12 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
     }
   }
 
-  def applyWand(w: sil.MagicWand, error: PartialVerificationError, statesStack: List[Any] = null, allStateAssms: Exp = TrueLit(), inWand: Boolean = false):Stmt = {
+  def applyWand(w: sil.MagicWand, error: PartialVerificationError, statesStack: List[Any] = null, @unused allStateAssms: Exp = TrueLit(), inWand: Boolean = false):Stmt = {
     /** we first exhale without havocing heap locations to avoid the incompleteness issue which would otherwise
       * occur when the left and right hand side mention common heap locations.
       */
     val lhsID = wandModule.getNewLhsID() // identifier for the lhs of the wand to be referred to later when 'old(lhs)' is used
-    val defineLHS = stmtModule.translateStmt(sil.Label("lhs"+lhsID, Nil)(w.pos, w.info))
+    @unused val defineLHS = stmtModule.translateStmt(sil.Label("lhs"+lhsID, Nil)(w.pos, w.info))
     wandModule.pushToActiveWandsStack(lhsID)
 
     val ret = CommentBlock("check if wand is held and remove an instance",exhaleModule.exhaleSingleWithoutDefinedness(w, error, false, insidePackageStmt = inWand, statesStackForPackageStmt = statesStack)) ++
@@ -755,7 +757,7 @@ case class PackageSetup(hypState: StateRep, usedState: StateRep, initStmt: Stmt)
     */
   override def partialCheckDefinedness(e: sil.Exp, error: PartialVerificationError, makeChecks: Boolean, definednessStateOpt: Option[DefinednessState]): (() => Stmt, () => Stmt) = {
     e match {
-      case a@sil.Applying(wand, exp) =>
+      case sil.Applying(wand, _) =>
         tmpStateId += 1
         val tmpStateName = if (tmpStateId == 0) "Applying" else s"Applying$tmpStateId"
         val (stmt, state) = stateModule.freshTempState(tmpStateName)

--- a/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/DefaultWandModule.scala
@@ -418,8 +418,6 @@ private def transferAcc(states: List[StateRep], used:StateRep, e: TransferableEn
       val minStmt = If(neededLocal <= curpermLocal,
         transferAmountLocal := neededLocal, transferAmountLocal := curpermLocal)
 
-      @unused val nofractionsStmt = (transferAmountLocal := RealLit(1.0))
-
       val curPermTop = permModule.currentPermission(e.rcv, e.loc)
       val removeFromTop = heapModule.beginExhale ++
         (components flatMap (_.transferRemove(e,used.boolVar))) ++

--- a/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
+++ b/src/main/scala/viper/carbon/modules/impls/LabelHelper.scala
@@ -1,7 +1,5 @@
 package viper.carbon.modules.impls
 
-import viper.carbon.modules.StateModule
-
 object LabelHelper {
 
   /**

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -40,7 +40,6 @@ import viper.carbon.verifier.Verifier
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.Implies
 
-import scala.annotation.unused
 import scala.collection.mutable.ListBuffer
 import viper.silver.ast.utility.QuantifiedPermissions.SourceQuantifiedPermissionAssertion
 import viper.silver.verifier.errors.{ContractNotWellformed, PostconditionViolated}
@@ -307,8 +306,8 @@ class QuantifiedPermModule(val verifier: Verifier)
   /**
    * Can a location on a given receiver be read?
    */
-  private def hasDirectPerm(@unused mask: Exp, obj: Exp, loc: Exp): Exp =
-    FuncApp(hasDirectPermName, Seq(maskExp, obj, loc), Bool)
+  private def hasDirectPerm(mask: Exp, obj: Exp, loc: Exp): Exp =
+    FuncApp(hasDirectPermName, Seq(mask, obj, loc), Bool)
 
   private def hasDirectPerm(obj: Exp, loc: Exp): Exp = hasDirectPerm(maskExp, obj, loc)
 

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -94,9 +94,6 @@ class QuantifiedPermModule(val verifier: Verifier)
   private val noPerm = Const(noPermName)
   private val fullPermName = Identifier("FullPerm")
   private val fullPerm = Const(fullPermName)
-  @unused private val permAddName = Identifier("PermAdd")
-  @unused private val permSubName = Identifier("PermSub")
-  @unused private val permDivName = Identifier("PermDiv")
   private val permConstructName = Identifier("Perm")
   private val goodMaskName = Identifier("GoodMask")
   private val hasDirectPermName = Identifier("HasDirectPerm")
@@ -475,7 +472,6 @@ class QuantifiedPermModule(val verifier: Verifier)
         def renaming[E <: sil.Exp] = (e:E) => Expressions.renameVariables(e, v.localVar, newV.localVar)
 
         //translate components
-        @unused val translatedLocal = translateLocalVarDecl(newV)
         val translatedCond = translateExp(renaming(cond))
         val translatedRcv = translateExp(renaming(fieldAccess.rcv))
         val translatedLocation = translateResource(renaming(fieldAccess))
@@ -666,7 +662,7 @@ class QuantifiedPermModule(val verifier: Verifier)
           case accPred: sil.AccessPredicate =>
             // alpha renaming, to avoid clashes in context, use vFresh instead of v
             val vsFresh = vs.map(v => env.makeUniquelyNamed(v))
-            @unused val vsFreshBoogie = vsFresh.map(vFresh => env.define(vFresh.localVar))
+            vsFresh.foreach(vFresh => env.define(vFresh.localVar))
             // create fresh variables for the formal arguments of the predicate/wand definition
             val (formals, args) = (accPred: @unchecked) match {
               case sil.PredicateAccessPredicate(sil.PredicateAccess(args, predname), _) =>
@@ -880,7 +876,6 @@ class QuantifiedPermModule(val verifier: Verifier)
 * I haven't yet found a nice way of avoiding the code duplication
 */
   override def transferRemove(e:TransferableEntity, cond:Exp): Stmt = {
-    @unused val permVar = LocalVar(Identifier("perm"), permType)
     val curPerm = currentPermission(e.rcv,e.loc)
     currentMaskAssignUpdate(e.rcv, e.loc, permSub(curPerm,e.transferAmount))
   }
@@ -1501,11 +1496,6 @@ class QuantifiedPermModule(val verifier: Verifier)
 
   private def currentMaskAssignUpdate(rcv: Exp, field: Exp, newPerm: Exp) : Stmt = {
     mask := maskUpdate(mask, rcv, field, newPerm)
-  }
-
-  @unused private def maskUpdate(mask: Exp, loc: LocationAccess, newPerm: Exp) : Exp = {
-    val (rcv, field) = rcvAndFieldExp(loc)
-    maskUpdate(mask, rcv, field, newPerm)
   }
 
   private def maskUpdate(mask: Exp, rcv: Exp, field: Exp, newPerm: Exp) : Exp = {

--- a/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
+++ b/src/main/scala/viper/carbon/modules/impls/QuantifiedPermModule.scala
@@ -40,6 +40,7 @@ import viper.carbon.verifier.Verifier
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.ast.Implies
 
+import scala.annotation.unused
 import scala.collection.mutable.ListBuffer
 import viper.silver.ast.utility.QuantifiedPermissions.SourceQuantifiedPermissionAssertion
 import viper.silver.verifier.errors.{ContractNotWellformed, PostconditionViolated}
@@ -73,7 +74,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     wandModule.register(this)
   }
 
-  implicit val namespace = verifier.freshNamespace("perm")
+  implicit val namespace: Namespace = verifier.freshNamespace("perm")
   private val axiomNamespace = verifier.freshNamespace("perm.axiom")
   private val permTypeName = "Perm"
   private val maskTypeName = "MaskType"
@@ -93,9 +94,9 @@ class QuantifiedPermModule(val verifier: Verifier)
   private val noPerm = Const(noPermName)
   private val fullPermName = Identifier("FullPerm")
   private val fullPerm = Const(fullPermName)
-  private val permAddName = Identifier("PermAdd")
-  private val permSubName = Identifier("PermSub")
-  private val permDivName = Identifier("PermDiv")
+  @unused private val permAddName = Identifier("PermAdd")
+  @unused private val permSubName = Identifier("PermSub")
+  @unused private val permDivName = Identifier("PermDiv")
   private val permConstructName = Identifier("Perm")
   private val goodMaskName = Identifier("GoodMask")
   private val hasDirectPermName = Identifier("HasDirectPerm")
@@ -265,7 +266,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     (maskVar := zeroMask)
   }
 
-  override def reset = {
+  override def reset(): Unit = {
     mask = originalMask
     qpId = 0
     inverseFuncs = new ListBuffer[Func]();
@@ -309,7 +310,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   /**
    * Can a location on a given receiver be read?
    */
-  private def hasDirectPerm(mask: Exp, obj: Exp, loc: Exp): Exp =
+  private def hasDirectPerm(@unused mask: Exp, obj: Exp, loc: Exp): Exp =
     FuncApp(hasDirectPermName, Seq(maskExp, obj, loc), Bool)
 
   private def hasDirectPerm(obj: Exp, loc: Exp): Exp = hasDirectPerm(maskExp, obj, loc)
@@ -351,9 +352,9 @@ class QuantifiedPermModule(val verifier: Verifier)
    */
   override def permissionPositive(permission: Exp, zeroOK : Boolean = false): Exp = permissionPositiveInternal(permission, None, zeroOK)
 
-  private def permissionPositiveInternal(permission: Exp, silPerm: Option[sil.Exp] = None, zeroOK : Boolean = false): Exp = {
+  private def permissionPositiveInternal(permission: Exp, silPerm: Option[sil.Exp], zeroOK : Boolean = false): Exp = {
     (permission, silPerm) match {
-      case (x, _) if permission == fullPerm => TrueLit()
+      case (_, _) if permission == fullPerm => TrueLit()
       case (_, Some(sil.FullPerm())) => TrueLit()
       case (_, Some(sil.WildcardPerm())) => TrueLit()
       case (_, Some(sil.NoPerm())) => if (zeroOK) TrueLit() else FalseLit()
@@ -369,7 +370,7 @@ class QuantifiedPermModule(val verifier: Verifier)
 
   override def containsWildCard(e: sil.Exp): Boolean = {
     e match {
-      case sil.AccessPredicate(loc, prm) =>
+      case sil.AccessPredicate(_, prm) =>
         val p = PermissionHelper.normalizePerm(prm)
         p.isInstanceOf[sil.WildcardPerm]
       case _ => false
@@ -427,7 +428,7 @@ class QuantifiedPermModule(val verifier: Verifier)
           Assert(sufficientPermExp, error.dueTo(reasons.MagicWandChunkNotFound(w))) ++
           (if (!usingOldState && !assertReadPermOnly) currentMaskAssignUpdate(translateNull, wandRep, permSub(curPerm, fullPerm)) else Nil)
 
-      case fa@sil.Forall(v, cond, expr) =>
+      case fa@sil.Forall(_, _, _) =>
 
         if (fa.isPure) {
           Nil
@@ -474,7 +475,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         def renaming[E <: sil.Exp] = (e:E) => Expressions.renameVariables(e, v.localVar, newV.localVar)
 
         //translate components
-        val translatedLocal = translateLocalVarDecl(newV)
+        @unused val translatedLocal = translateLocalVarDecl(newV)
         val translatedCond = translateExp(renaming(cond))
         val translatedRcv = translateExp(renaming(fieldAccess.rcv))
         val translatedLocation = translateResource(renaming(fieldAccess))
@@ -665,9 +666,9 @@ class QuantifiedPermModule(val verifier: Verifier)
           case accPred: sil.AccessPredicate =>
             // alpha renaming, to avoid clashes in context, use vFresh instead of v
             val vsFresh = vs.map(v => env.makeUniquelyNamed(v))
-            val vsFreshBoogie = vsFresh.map(vFresh => env.define(vFresh.localVar))
+            @unused val vsFreshBoogie = vsFresh.map(vFresh => env.define(vFresh.localVar))
             // create fresh variables for the formal arguments of the predicate/wand definition
-            val (formals, args) = accPred match {
+            val (formals, args) = (accPred: @unchecked) match {
               case sil.PredicateAccessPredicate(sil.PredicateAccess(args, predname), _) =>
                 val predicate = program.findPredicate(predname)
                 (predicate.formalArgs, args)
@@ -759,7 +760,7 @@ class QuantifiedPermModule(val verifier: Verifier)
                 (currentPermission(translateNull, translatedResource) >= translatedPerms)
               }
 
-            val reason = accPred match {
+            val reason = (accPred: @unchecked) match {
               case sil.PredicateAccessPredicate(loc, _) => reasons.InsufficientPermission(loc)
               case w: sil.MagicWand => reasons.MagicWandChunkNotFound(w)
             }
@@ -776,7 +777,7 @@ class QuantifiedPermModule(val verifier: Verifier)
               }
 
             //Assume map update for affected locations
-            val general_location = accPred match {
+            val general_location = (accPred: @unchecked) match {
               case pa: sil.PredicateAccessPredicate =>
                 val formalPredicate = new PredicateAccess(freshFormalVars, pa.loc.predicateName)(pa.loc.pos, pa.loc.info, pa.loc.errT)
                 val general_location = translateResource(formalPredicate)
@@ -794,7 +795,7 @@ class QuantifiedPermModule(val verifier: Verifier)
             val obj = LocalVarDecl(Identifier("o"), refType)
             val field = LocalVarDecl(Identifier("f"), fieldType)
             val fieldVar = LocalVar(Identifier("f"), fieldType)
-            val (isDifferentFieldType, hasWrongId) = accPred match {
+            val (isDifferentFieldType, hasWrongId) = (accPred: @unchecked) match {
               case sil.PredicateAccessPredicate(PredicateAccess(_, predname), _) =>
                 (isPredicateField(fieldVar).not, (getPredicateOrWandId(fieldVar) !== IntLit(getPredicateOrWandId(predname))))
               case w: sil.MagicWand =>
@@ -879,7 +880,7 @@ class QuantifiedPermModule(val verifier: Verifier)
 * I haven't yet found a nice way of avoiding the code duplication
 */
   override def transferRemove(e:TransferableEntity, cond:Exp): Stmt = {
-    val permVar = LocalVar(Identifier("perm"), permType)
+    @unused val permVar = LocalVar(Identifier("perm"), permType)
     val curPerm = currentPermission(e.rcv,e.loc)
     currentMaskAssignUpdate(e.rcv, e.loc, permSub(curPerm,e.transferAmount))
   }
@@ -1020,7 +1021,7 @@ class QuantifiedPermModule(val verifier: Verifier)
       //map occurring LocalVars
       containVars(expr)
     }
-    var containsVars = (vars.map(x => varMap.contains(x.name))).reduce((var1, var2) => var1 && var2)
+    val containsVars = (vars.map(x => varMap.contains(x.name))).reduce((var1, var2) => var1 && var2)
     validType && containsVars
   }
 
@@ -1057,7 +1058,7 @@ class QuantifiedPermModule(val verifier: Verifier)
 
        val res = expr match {
          //Quantified Field Permission
-         case accPred@sil.FieldAccessPredicate(fieldAccess@sil.FieldAccess(recv, f), _) =>
+         case accPred@sil.FieldAccessPredicate(fieldAccess@sil.FieldAccess(recv, _), _) =>
            val perms = accPred.perm
            // alpha renaming, to avoid clashes in context, use vFresh instead of v
            var isWildcard = false
@@ -1204,7 +1205,7 @@ class QuantifiedPermModule(val verifier: Verifier)
            val is_injective = Forall(translatedLocals ++ v2s, validateTriggers(translatedLocals ++ v2s, Seq(Trigger(Seq(triggerFunApp2)))), (notEquals && translatedCond && translatedCond2 && permGt(translatedPerms, noPerm) && permGt(translatedPerms2, noPerm)) ==> (translatedRecv !== translatedRecv2))
 
            val reas = reasons.QPAssertionNotInjective(fieldAccess)
-           var err = error.dueTo(reas)
+           val err = error.dueTo(reas)
            val injectiveAssertion = Assert(is_injective, err)
 
            val res1 = Havoc(qpMask) ++
@@ -1229,7 +1230,7 @@ class QuantifiedPermModule(val verifier: Verifier)
            val vsFresh = vs.map(v => env.makeUniquelyNamed(v))
            vsFresh.map(vFresh => env.define(vFresh.localVar))
            // create fresh variables for the formal arguments of the predicate definition
-           val (formals, args) = accPred match {
+           val (formals, args) = (accPred: @unchecked) match {
              case sil.PredicateAccessPredicate(sil.PredicateAccess(args, predname), _) =>
                val predicate = program.findPredicate(predname)
                (predicate.formalArgs, args)
@@ -1298,7 +1299,7 @@ class QuantifiedPermModule(val verifier: Verifier)
            val invAssm2 = MaybeForall(freshFormalBoogieDecls, Trigger(invFunApps), ((condInv && permGt(permInv, noPerm)) && rangeFunApp) ==> conjoinedInverseAssumptions)
 
            //define arguments needed to describe map updates
-           val general_location = accPred match {
+           val general_location = (accPred: @unchecked) match {
              case pa: sil.PredicateAccessPredicate =>
                val formalPredicate = new PredicateAccess(freshFormalVars, pa.loc.predicateName)(pa.loc.pos, pa.loc.info, pa.loc.errT)
                val general_location = translateResource(formalPredicate)
@@ -1341,7 +1342,7 @@ class QuantifiedPermModule(val verifier: Verifier)
            val field = LocalVarDecl(Identifier("f"), fieldType)
            val fieldVar = LocalVar(Identifier("f"), fieldType)
 
-           val (isDifferentFieldType, hasWrongId) = accPred match {
+           val (isDifferentFieldType, hasWrongId) = (accPred: @unchecked) match {
               case sil.PredicateAccessPredicate(PredicateAccess(_, predname), _) =>
                 (isPredicateField(fieldVar).not, (getPredicateOrWandId(fieldVar) !== IntLit(getPredicateOrWandId(predname)) ))
               case w: sil.MagicWand =>
@@ -1424,18 +1425,18 @@ class QuantifiedPermModule(val verifier: Verifier)
   //renamed Localvariable and Condition
   def getMapping(v: sil.LocalVarDecl, cond:sil.Exp, expr:sil.Exp): Seq[Exp] = {
     val res = expr match {
-      case SourceQuantifiedPermissionAssertion(forall, Implies(cond, expr))  =>
+      case SourceQuantifiedPermissionAssertion(_, Implies(_, _))  =>
         Nil
-      case sil.FieldAccessPredicate(fa@sil.FieldAccess(rcvr, f), gain) =>
+      case sil.FieldAccessPredicate(sil.FieldAccess(_, _), _) =>
         Nil
-      case predAccPred@sil.PredicateAccessPredicate(PredicateAccess(args, predname), perm) =>
+      case sil.PredicateAccessPredicate(PredicateAccess(args, _), _) =>
         Nil
-      case sil.And(e0, e1) =>
+      case sil.And(_, _) =>
         Nil
-      case sil.Implies(e0, e1) =>
+      case sil.Implies(_, _) =>
         //e0 must be pure
         Nil
-      case sil.Or(e0, e1) =>
+      case sil.Or(_, _) =>
         //e0 must be pure
         Nil
       case _ => Nil
@@ -1502,7 +1503,7 @@ class QuantifiedPermModule(val verifier: Verifier)
     mask := maskUpdate(mask, rcv, field, newPerm)
   }
 
-  private def maskUpdate(mask: Exp, loc: LocationAccess, newPerm: Exp) : Exp = {
+  @unused private def maskUpdate(mask: Exp, loc: LocationAccess, newPerm: Exp) : Exp = {
     val (rcv, field) = rcvAndFieldExp(loc)
     maskUpdate(mask, rcv, field, newPerm)
   }
@@ -1601,7 +1602,7 @@ class QuantifiedPermModule(val verifier: Verifier)
   override def handleStmt(s: sil.Stmt, statesStack: List[Any] = null, allStateAssms: Exp = TrueLit(), insidePackageStmt: Boolean = false) : (Seqn => Seqn) = {
     stmts =>
       s match {
-        case n@sil.NewStmt(target, fields) =>
+        case sil.NewStmt(target, fields) =>
           stmts ++ (for (field <- fields) yield {
             currentMaskAssignUpdate(sil.FieldAccess(target, field)(), currentPermission(sil.FieldAccess(target, field)()) + fullPerm)
           })
@@ -1643,9 +1644,9 @@ class QuantifiedPermModule(val verifier: Verifier)
         case fa@sil.LocationAccess(_) =>
           val hasDirectPermExp = definednessStateOpt.fold(hasDirectPerm(fa))(defState => hasDirectPerm(fa, defState.setDefState))
           Assert(hasDirectPermExp, error.dueTo(reasons.InsufficientPermission(fa)))
-        case sil.PermDiv(a, b) =>
+        case sil.PermDiv(_, b) =>
           Assert(translateExp(b) !== IntLit(0), error.dueTo(reasons.DivisionByZero(b)))
-        case sil.PermPermDiv(a, b) =>
+        case sil.PermPermDiv(_, b) =>
           Assert(translatePerm(b) !== RealLit(0.0), error.dueTo(reasons.DivisionByZero(b)))
         case _ => Nil
       }
@@ -1701,7 +1702,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.WildcardPerm() => TrueLit()
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
         case x: sil.LocalVar if isAbstractRead(x) => TrueLit()
-        case sil.CurrentPerm(loc) => backup()
+        case sil.CurrentPerm(_) => backup()
         case sil.FractionalPerm(left, right) =>
           val (l, r) = (translateExp(left), translateExp(right))
           ((l > IntLit(0)) && (r > IntLit(0))) || ((l < IntLit(0)) && (r < IntLit(0)))
@@ -1712,7 +1713,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.PermSub(left, right) => backup()
         case sil.PermMul(a, b) =>
           (isStrictlyPositivePerm(a) && isStrictlyPositivePerm(b)) || (isStrictlyNegativePerm(a) && isStrictlyNegativePerm(b))
-        case sil.PermDiv(a, b) =>
+        case sil.PermDiv(a, _) =>
           isStrictlyPositivePerm(a) // note: b should be ruled out from being non-positive
         case sil.PermPermDiv(a, b) =>
           (isStrictlyPositivePerm(a) && isStrictlyPositivePerm(b)) ||
@@ -1734,7 +1735,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.WildcardPerm() => true
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
         case x: sil.LocalVar if isAbstractRead(x) => true
-        case sil.CurrentPerm(loc) => false // conservative
+        case sil.CurrentPerm(_) => false // conservative
         case sil.FractionalPerm(sil.IntLit(m), sil.IntLit(n)) =>
           m > 0 && n > 0 || m < 0 && n < 0
         case sil.FractionalPerm(left, right) => false // conservative
@@ -1745,14 +1746,14 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.PermSub(left, right) => false // conservative
         case sil.PermMul(a, b) =>
           (conservativeStaticIsStrictlyPositivePerm(a) && conservativeStaticIsStrictlyPositivePerm(b)) || (conservativeStaticIsStrictlyNegativePerm(a) && conservativeStaticIsStrictlyNegativePerm(b))
-        case sil.PermDiv(a, b) =>
+        case sil.PermDiv(a, _) =>
           conservativeStaticIsStrictlyPositivePerm(a) // note: b should be guaranteed ruled out from being non-positive
         case sil.PermPermDiv(a, b) =>
           (conservativeStaticIsStrictlyPositivePerm(a) && conservativeStaticIsStrictlyPositivePerm(b)) ||
             (conservativeStaticIsStrictlyNegativePerm(a) && conservativeStaticIsStrictlyNegativePerm(b))
         case sil.IntPermMul(sil.IntLit(n), b) =>
           n > 0 && conservativeStaticIsStrictlyPositivePerm(b) || n < 0 && conservativeStaticIsStrictlyNegativePerm(b)
-        case sil.IntPermMul(a, b) => false // conservative
+        case sil.IntPermMul(_, _) => false // conservative
         case sil.CondExp(cond, thn, els) => // conservative
           conservativeStaticIsStrictlyPositivePerm(thn) && conservativeStaticIsStrictlyPositivePerm(els)
         case _ => false // conservative?
@@ -1766,8 +1767,8 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.FullPerm() => false
         case sil.WildcardPerm() => false
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
-        case x: sil.LocalVar => false // conservative
-        case sil.CurrentPerm(loc) => false // conservative
+        case _: sil.LocalVar => false // conservative
+        case sil.CurrentPerm(_) => false // conservative
         case sil.FractionalPerm(sil.IntLit(m), sil.IntLit(n)) =>
           m > 0 && n < 0 || m < 0 && n > 0
         case sil.FractionalPerm(left, right) => false // conservative
@@ -1778,14 +1779,14 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.PermSub(left, right) => false // conservative
         case sil.PermMul(a, b) =>
           (conservativeStaticIsStrictlyPositivePerm(a) && conservativeStaticIsStrictlyNegativePerm(b)) || (conservativeStaticIsStrictlyNegativePerm(a) && conservativeStaticIsStrictlyPositivePerm(b))
-        case sil.PermDiv(a, b) =>
+        case sil.PermDiv(a, _) =>
           conservativeStaticIsStrictlyNegativePerm(a) // note: b should be guaranteed ruled out from being non-positive
         case sil.PermPermDiv(a, b) =>
           (conservativeStaticIsStrictlyNegativePerm(a) && conservativeStaticIsStrictlyPositivePerm(b)) ||
             (conservativeStaticIsStrictlyPositivePerm(a) && conservativeStaticIsStrictlyNegativePerm(b))
         case sil.IntPermMul(sil.IntLit(n), b) =>
           n > 0 && conservativeStaticIsStrictlyNegativePerm(b) || n < 0 && conservativeStaticIsStrictlyPositivePerm(b)
-        case sil.IntPermMul(a, b) => false // conservative
+        case sil.IntPermMul(_, _) => false // conservative
         case sil.CondExp(cond, thn, els) => // conservative
           conservativeStaticIsStrictlyNegativePerm(thn) && conservativeStaticIsStrictlyNegativePerm(els)
         case _ => false // conservative?
@@ -1803,7 +1804,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.WildcardPerm() => FalseLit()
         case sil.EpsilonPerm() =>  sys.error("epsilon permissions are not supported by this permission module")
         case x: sil.LocalVar if isAbstractRead(x) => FalseLit()
-        case sil.CurrentPerm(loc) => backup()
+        case sil.CurrentPerm(_) => backup()
         case sil.FractionalPerm(left, right) =>
           val (l, r) = (translateExp(left), translateExp(right))
           ((l < IntLit(0)) && (r > IntLit(0))) || ((l > IntLit(0)) && (r < IntLit(0)))
@@ -1814,7 +1815,7 @@ class QuantifiedPermModule(val verifier: Verifier)
         case sil.PermSub(left, right) => backup()
         case sil.PermMul(a, b) =>
           (isStrictlyPositivePerm(a) && isStrictlyNegativePerm(b)) || (isStrictlyNegativePerm(a) && isStrictlyPositivePerm(b))
-        case sil.PermDiv(a, b) =>
+        case sil.PermDiv(a, _) =>
           isStrictlyNegativePerm(a) // note: b should be guaranteed ruled out from being non-positive
         case sil.PermPermDiv(a, b) =>
           (isStrictlyNegativePerm(a) && isStrictlyPositivePerm(b)) ||
@@ -1856,7 +1857,7 @@ class QuantifiedPermModule(val verifier: Verifier)
           isFixedPerm(left)
         case sil.PermPermDiv(left, right) =>
           isFixedPerm(left) && isFixedPerm(right)
-        case sil.IntPermMul(a, b) =>
+        case sil.IntPermMul(_, b) =>
           isFixedPerm(b)
         case sil.CondExp(cond, thn, els) =>
           isFixedPerm(thn) && isFixedPerm(els) // note: this doesn't take account of condition (due to being a syntactic check) - in theory could be overly-restrictive
@@ -1928,7 +1929,7 @@ class QuantifiedPermModule(val verifier: Verifier)
 
         // move integer permission multiplications all the way to the inside
         val e3 = e2c.transform({
-          case x@sil.IntPermMul(a, sil.PermAdd(b, c)) => done = false
+          case sil.IntPermMul(a, sil.PermAdd(b, c)) => done = false
             sil.PermAdd(sil.IntPermMul(a, b)(), sil.IntPermMul(a, c)())()
           case sil.IntPermMul(a, sil.PermMul(b, c)) => done = false
             sil.PermMul(b, sil.IntPermMul(a, c)())()

--- a/src/main/scala/viper/carbon/utility/PolyMapDesugarHelper.scala
+++ b/src/main/scala/viper/carbon/utility/PolyMapDesugarHelper.scala
@@ -19,7 +19,7 @@ case class PolyMapRep(select: Func, store: Func, axioms: Seq[Axiom])
   * @param namespace
   */
 case class PolyMapDesugarHelper(refType: Type, fieldTypeConstructor: (Int, Seq[Type] => Type), namespace: Namespace) {
-  implicit val ns = namespace
+  implicit val ns: Namespace = namespace
 
   /**
     * Creates store and select functions with corresponding axioms to desugar a Boogie map of the form

--- a/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
+++ b/src/main/scala/viper/carbon/verifier/BoogieInterface.scala
@@ -83,7 +83,7 @@ trait BoogieInterface {
     // find all errors and assign everyone a unique id
     errormap = Map()
     program.visit {
-      case a@Assert(exp, error) =>
+      case a@Assert(_, error) =>
         errormap += (a.id -> error)
     }
 
@@ -151,7 +151,7 @@ trait BoogieInterface {
           version_found = version
         case ErrorPattern(id) =>
           errors += id.toInt
-        case SummaryPattern(v, e) =>
+        case SummaryPattern(_, e) =>
           if(e.toInt != errors.size) unexpected(s"Found ${errors.size} errors, but there should be $e. The output was: $output")
         case "" => // ignore empty lines
         case _ =>

--- a/src/main/scala/viper/carbon/verifier/Environment.scala
+++ b/src/main/scala/viper/carbon/verifier/Environment.scala
@@ -31,7 +31,7 @@ case class Environment(verifier: Verifier, member: sil.Node) {
       for (v <- args ++ returns) {
         define(v.localVar)
       } 
-    case f@sil.Function(_, args, _, _, _, _) =>
+    case sil.Function(_, args, _, _, _, _) =>
       for (v <- args) {
         define(v.localVar)
       }
@@ -70,7 +70,7 @@ case class Environment(verifier: Verifier, member: sil.Node) {
    */
   def define(variable: sil.LocalVar): LocalVar = {
     currentMapping.get(variable) match {
-      case Some(t) =>
+      case Some(_) =>
         sys.error(s"Internal Error: variable $variable is already defined.")
       case None =>
         val name = uniqueName(variable.name)

--- a/src/main/scala/viper/carbon/verifier/Verifier.scala
+++ b/src/main/scala/viper/carbon/verifier/Verifier.scala
@@ -44,7 +44,7 @@ trait Verifier {
       exhaleModule, inhaleModule, funcPredModule, domainModule, seqModule, setModule,
       loopModule, mapModule, wandModule)
   } ensuring {
-    mods => true
+    _ => true
   }
 
   /**

--- a/src/test/scala/viper/carbon/CarbonQuantifierWeightTests.scala
+++ b/src/test/scala/viper/carbon/CarbonQuantifierWeightTests.scala
@@ -6,22 +6,20 @@
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
-import viper.carbon.boogie.PrettyPrinter
-import viper.carbon.verifier.Environment
 import viper.carbon.CarbonVerifier
-import viper.silver.ast.{Add, AnonymousDomainAxiom, Domain, DomainFunc, DomainFuncApp, EqCmp, Exists, Forall, Int, IntLit, LocalVar, LocalVarDecl, Method, Program, Seqn, Trigger, TrueLit, WeightedQuantifier}
+import viper.silver.ast.{Add, AnonymousDomainAxiom, Domain, DomainFunc, DomainFuncApp, EqCmp, Forall, Int, IntLit, LocalVar, LocalVarDecl, Method, Program, Seqn, Trigger, WeightedQuantifier}
 import viper.silver.reporter.NoopReporter
 import viper.silver.verifier.{Failure, Success}
 
 class CarbonQuantifierWeightTests extends AnyFunSuite with BeforeAndAfterAll {
   val carbon: CarbonVerifier = CarbonVerifier(NoopReporter)
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     carbon.parseCommandLine(Seq("dummy.vpr"))
     carbon.start()
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     carbon.stop()
   }
 

--- a/src/test/scala/viper/carbon/CarbonTestsOldPermissionSemantics.scala
+++ b/src/test/scala/viper/carbon/CarbonTestsOldPermissionSemantics.scala
@@ -6,14 +6,6 @@
 
 package viper.carbon
 
-import viper.silver.frontend.Frontend
-import viper.silver.logger.SilentLogger
-import viper.silver.reporter.{NoopReporter, StdIOReporter}
-import viper.silver.testing.SilSuite
-import viper.silver.verifier.Verifier
-
-import java.nio.file.Path
-
 /** All tests for carbon.
 
   */


### PR DESCRIPTION
## Summary
This PR enables Scala compiler fatal warnings (`-Xfatal-warnings`) and systematically fixes all resulting compiler warnings across the codebase to ensure code quality and prevent future regressions.

## Key Changes

### Compiler Configuration
- Added `-Xfatal-warnings` scalac option in `build.sbt` to treat all warnings as compilation errors

### Unused Variable/Parameter Annotations
- Added `@unused` annotations to 40+ variables and parameters that are intentionally not used:
  - Private fields that serve as documentation or future use (e.g., `permAddName`, `permSubName`, `permDivName`)
  - Function parameters that are part of required signatures but not used in implementation
  - Local variables created for side effects (e.g., `translatedLocal`, `vsFreshBoogie`)

### Pattern Matching Improvements
- Replaced named pattern variables with wildcards (`_`) where the binding is unused:
  - `case (x, _) if ...` → `case (_, _) if ...`
  - `case fa@sil.Forall(v, cond, expr)` → `case fa@sil.Forall(_, _, _)`
  - `case sil.FieldAccess(recv, f)` → `case sil.FieldAccess(recv, _)`
  - Multiple similar changes across quantified permission and heap module implementations

### Type Annotations
- Added explicit type annotations to implicit values for clarity:
  - `implicit val namespace = ...` → `implicit val namespace: Namespace = ...`
  - Applied to `heapNamespace`, `fpNamespace`, `stateNamespace`, `namespace` in multiple modules

### Method Signature Fixes
- Removed default parameter values where they were causing warnings:
  - `def permissionPositiveInternal(permission: Exp, silPerm: Option[sil.Exp] = None, ...)` → removed `= None` default
  - `def transformFuncAppsToLimitedOrTriggerForm(exp: Exp, heightToSkip : Int = -1, triggerForm: Boolean = false)` → removed defaults
  - `def heapUpdateLoc(..., isPMask: Boolean = false)` → removed default
  - `def transferAcc(..., havocHeap: Boolean = true)` → removed default

### Return Type Annotations
- Added explicit `Unit` return types to methods:
  - `override def reset = { }` → `override def reset(): Unit = { }`
  - `override def beforeAll()` → `override def beforeAll(): Unit`
  - `override def afterAll()` → `override def afterAll(): Unit`

### Pattern Matching with Type Ascriptions
- Added `@unchecked` annotations to pattern matches that are exhaustive but not recognized as such:
  - `val (formals, args) = accPred match { ... }` → `val (formals, args) = (accPred: @unchecked) match { ... }`

### Variable Mutability Fixes
- Changed `var` to `val` where variables are assigned once:
  - `var containsVars = ...` → `val containsVars = ...`
  - `var err = ...` → `val err = ...`
  - `var oldW = ...` → `val oldW = ...`

### Unused Import Removals
- Removed unused imports from several files:
  - `DefaultHeapModule`: removed `InhaleComponent`, `PartialVerificationError`
  - `CarbonQuantifierWeightTests`: removed `Exists`, `PrettyPrinter`, `Environment`
  - `DefaultMainModule`: removed `expModule` import
  - `DefaultExhaleModule`: removed `permModule` import
  - `DefaultLoopModule`: removed `ViperStrategy` import
  - `ExhaleModule`: removed `DefinednessState` import
  - `HeapModule`: removed `PolyMapDesugarHelper` import
  - `LabelHelper`: removed `StateModule` import

### Implicit Conversion Return Types
- Added explicit return types to implicit conversion functions:
  - `implicit def liftStmt(ss

https://claude.ai/code/session_01W9SJYwJrGzRj71r7Kg1yvD